### PR TITLE
implement WidgetConfig as a Proxy.

### DIFF
--- a/demo/widgy.py
+++ b/demo/widgy.py
@@ -1,17 +1,32 @@
 from __future__ import absolute_import
 
 from widgy.site import WidgySite
-from widgy.contrib.page_builder.models import Accordion, Section
+from widgy.contrib.page_builder.models import Accordion
+from widgy import registry, WidgetConfig
 
 from demo.demo_widgets.models import TwoContentLayout
 
 
 class DemoWidgySite(WidgySite):
-    def valid_parent_of(self, parent, child_class, child=None):
-
-        if isinstance(parent, Accordion) and isinstance(parent.get_root(), TwoContentLayout) and issubclass(child_class, Section) and len(parent.children) >= 2:
-            if not child or child not in parent.children:
-                return False
-        return super(DemoWidgySite, self).valid_parent_of(parent, child_class, child)
+    pass
 
 widgy_site = DemoWidgySite()
+
+
+registry.unregister(Accordion)
+
+
+class DemoAccordionConfig(WidgetConfig):
+    @property
+    def max_number_of_children(self):
+        """
+        If I live in the TwoContentLayout, I only should have max
+        two children.
+        """
+        if isinstance(self.get_root(), TwoContentLayout):
+            return 2
+        else:
+            return self.model.max_number_of_children
+
+
+registry.register(Accordion, DemoAccordionConfig)

--- a/tests/modeltests/core_tests/models.py
+++ b/tests/modeltests/core_tests/models.py
@@ -8,8 +8,6 @@ from .widgy_config import widgy_site
 
 
 class Layout(Content):
-    accepting_children = True
-
     @classmethod
     def valid_child_of(self, parent, obj=None):
         return False
@@ -23,7 +21,7 @@ class Layout(Content):
 
 
 class Bucket(Content):
-    accepting_children = True
+    pass
 
 
 class RawTextWidget(Content):

--- a/widgy/__init__.py
+++ b/widgy/__init__.py
@@ -1,16 +1,42 @@
 from django.core.exceptions import ImproperlyConfigured
+from django.db.models.base import ModelBase
+
+
+def model_to_proxy(model_class, config_class):
+    """
+    Creates a new class that has mixes in the config class with the model.
+    """
+    return type(config_class.__name__, (config_class, model_class), {})
+
+
+class WidgetConfigBase(ModelBase):
+    """
+    Don't do anything that ModelBase does in __new__.
+    """
+    def __new__(cls, name, bases, attrs):
+        return type(object).__new__(cls, name, bases, attrs)
 
 
 class WidgetConfig(object):
-    def __init__(self, site):
-        self.site = site
+    """
+    Implements a proxy object that will delegate to a model.  Additionally,
+    this class is mixed into the model class making it possible to only treat
+    self as the model.
+    """
+    __metaclass__ = WidgetConfigBase
+
+    def __init__(self, model):
+        self.model = model
+
+    def __getattr__(self, key):
+        return getattr(self.model, key)
 
 
 class Registry(dict):
     def register(self, content, config=WidgetConfig):
         if content in self:
             raise ImproperlyConfigured("You cannot register the same content ('{0}') twice.".format(content))
-        self[content] = config
+        self[content] = model_to_proxy(content, config)
 
     def unregister(self, content):
         del self[content]

--- a/widgy/models.py
+++ b/widgy/models.py
@@ -227,7 +227,7 @@ class Content(models.Model):
 
     draggable = True            #: Set this content to be draggable
     deletable = True            #: Set this content instance to be deleteable
-    accepting_children = False  #: Sets this content instance to be able to have children.
+    max_number_of_children = float('infinity')
     # 0: can not pop out
     # 1: can pop out
     # 2: must pop out
@@ -262,7 +262,6 @@ class Content(models.Model):
             'object_name': self._meta.object_name,
             'draggable': self.draggable,
             'deletable': self.deletable,
-            'accepting_children': self.accepting_children,
             'template_url': site.reverse(site.node_templates_view, kwargs={'node_pk': self.node.pk}),
             'preview_template': self.get_preview_template(),
             'pop_out': self.pop_out,
@@ -338,7 +337,7 @@ class Content(models.Model):
         Given a content class, can it be _added_ as our child?
         Note: this does not apply to _existing_ children (adoption)
         """
-        return self.accepting_children
+        return len(self.children) < self.max_number_of_children
 
     @classmethod
     def valid_child_of(cls, parent, obj=None):

--- a/widgy/site.py
+++ b/widgy/site.py
@@ -78,8 +78,15 @@ class WidgySite(object):
     def get_node_templates_view(self):
         return NodeTemplatesView.as_view(site=self)
 
+    def get_config_for_class(self, cls):
+        return self.get_registry()[cls]
+
+    def get_config(self, obj):
+        cls = self.get_config_for_class(type(obj))
+        return cls(model=obj)
+
     def valid_parent_of(self, parent, child_class, child=None):
-        return parent.valid_parent_of(child_class, child)
+        return self.get_config(parent).valid_parent_of(child_class, child)
 
     def valid_child_of(self, parent, child_class, child=None):
         return child_class.valid_child_of(parent, child)


### PR DESCRIPTION
When you write a WidgetConfig, it will be mixed into the model class and
when dealing with validation, the WidgySite will use the proxy
WidgetConfig.  By default, WidgetConfig implements nothing except a
delegation method.  But you can incrementally implement methods that you
need.  For example, the following implementation of bucket will accept
anything.

```
from widgy.models import Content
from widgy import registry

class Bucket(Content):
    pass

registry.register(Bucket)
```

But if you wanted it to be more selective, you could subclass it:

```
class VowelBucket(Bucket):
    """
    VowelBucket only accepts classes whose name starts with vowels.
    """
    def valid_parent_of(self, class, obj=None):
        return class.__name__[0].lower() in 'aeiou'

registry.register(VowelBucket)
```

However, subclassing it like this means that you would have two tables
in the database, and really none of the fields have changed.  Instead,
you could use a WidgetConfig to override the compatibility checking.

```
from widgy import WidgetConfig, registry

class VowelChildConfig(WidgetConfig):
    def valid_parent_of(self, class, obj=None):
        return class.__name__[0].lower() in 'aeiou'

registry.register(Bucket, VowelChildConfig)
```

This has the added benefit of being reusable.  For example, you could
make all of your Content classes only accept children whose classes
start with a vowel:

```
registry.register(OtherContainer, VowelChildConfig)
```

Additionally, this commit drops `accepting_children` in support of `max_number_of_children`.    I forgot to take it out when I was committing it because it was how I was rewriting my validation anyway.
