### PR TITLE
added collapsible nodes

### DIFF
--- a/widgy/static/widgy/css/widgy.scss
+++ b/widgy/static/widgy/css/widgy.scss
@@ -99,6 +99,17 @@
     }
   }
 
+  &:not(.node_in_motion) {
+    .node.collapsed {
+      font-weight: bold;
+      color: red;
+
+      & > .nodeChildren {
+        display: none;
+      }
+    }
+  }
+
   .node_drop_target {
     background: #fff;
     height: 25px;

--- a/widgy/static/widgy/js/nodes/nodes.js
+++ b/widgy/static/widgy/js/nodes/nodes.js
@@ -363,7 +363,8 @@ define([ 'exports', 'jquery', 'underscore', 'widgy.backbone', 'widgy.contents', 
       return _.extend({}, NodeViewBase.prototype.events , {
         'click .delete': 'delete',
         'click .pop_out': 'popOut',
-        'click .pop_in': 'popIn'
+        'click .pop_in': 'popIn',
+        'dblclick .title': 'toggleCollapse'
       });
     },
 
@@ -465,6 +466,12 @@ define([ 'exports', 'jquery', 'underscore', 'widgy.backbone', 'widgy.contents', 
       return false;
     },
 
+    toggleCollapse: function() {
+      this.$el.toggleClass('collapsed');
+
+      return false;
+    },
+
     startDrag: function(dragged_view) {
       debug.call(this, 'startDrag', dragged_view);
 
@@ -491,6 +498,7 @@ define([ 'exports', 'jquery', 'underscore', 'widgy.backbone', 'widgy.contents', 
 
         bindToDocument();
 
+        this.app.$el.addClass('node_in_motion');
         this.addDropTargets(dragged_view);
       } else {
         // propagate event
@@ -507,6 +515,7 @@ define([ 'exports', 'jquery', 'underscore', 'widgy.backbone', 'widgy.contents', 
       if ( dragged_view.placeholder )
         dragged_view.placeholder.remove();
 
+      this.app.$el.removeClass('node_in_motion');
       this.clearDropTargets();
 
       dragged_view.stopBeingDragged();


### PR DESCRIPTION
We thought it would be a good idea to provide collapsible nodes, because widgy can get super long.  Here is an implementation:
- [ ] is this discoverable enough?
- [ ] is this necessary?

Currently, when a node is collapsed it will open up when you are dragging a node.
