### PR TITLE
Node.find_widgy_problems -- detect tree inconsistencies

### DIFF
--- a/demo/settings.py
+++ b/demo/settings.py
@@ -342,6 +342,9 @@ MIDDLEWARE_CLASSES = (
     "urlconf_include.middleware.PatchUrlconfMiddleware",
     "mezzanine.pages.middleware.PageMiddleware",
     "mezzanine.core.middleware.FetchFromCacheMiddleware",
+    "django.middleware.transaction.TransactionMiddleware",
+    # prevent problems comes after transaction
+    "widgy.middleware.PreventProblemsMiddleware",
 )
 
 # Store these package names here as they may change in the future since

--- a/widgy/middleware.py
+++ b/widgy/middleware.py
@@ -1,0 +1,19 @@
+from widgy.models import Node
+
+class PreventProblemsMiddleware(object):
+    """
+    Checks if there are any 'problems' (inconsitensies in the widgy tree)
+    after every request. If used with TransactionMiddleware, it will
+    prevent problems from being committed by raising an exception. Useful
+    to turn on during development so you know right away if your code
+    corrupts the tree. It does an absurd number of queries though,
+    so probably not something to leave on all the time.
+    """
+
+    def get_problems(self):
+        return Node.find_problems() + Node.find_widgy_problems()
+
+    def process_response(self, request, response):
+        problems = self.get_problems()
+        assert not any(problems), "There are some problems: %s" % (problems,)
+        return response

--- a/widgy/models/base.py
+++ b/widgy/models/base.py
@@ -10,7 +10,6 @@ import copy
 
 from django.db import models
 from django.forms.models import modelform_factory, ModelForm
-from django.forms import model_to_dict
 from django.contrib.contenttypes.models import ContentType
 from django.template.loader import render_to_string
 from django.template import RequestContext
@@ -336,6 +335,29 @@ class Node(MP_Node):
             if not child.trees_equal(other_child):
                 return False
         return True
+
+    @classmethod
+    def find_widgy_problems(cls, site=None):
+        """
+        Searches all the nodes for inconsistencies.
+
+            - Nodes whose content doesn't exist
+            - Nodes whose content types don't exist (UnknownWidgets)
+
+        TODO: Maybe check for Content instances that don't have any nodes
+        pointing to them.
+        """
+
+        dangling, unknown = [], []
+
+        for node in cls.objects.all():
+            content = node.content
+            if not content:
+                dangling.append(node.id)
+            elif isinstance(content, UnknownWidget):
+                unknown.append(node.id)
+
+        return dangling, unknown
 
 
 def check_frozen(sender, instance, **kwargs):


### PR DESCRIPTION
Examines all the widgy trees looking for problems. Includes a
middleware to immediately detect and prevent problems.

While developing I'm coming across some bugs in my code that corrupt the tree. This middleware can be used to find these issues.
