### PR TITLE
Moves the preview link to the layout preview.html.

### DIFF
--- a/widgy/contrib/widgy_mezzanine/templates/widgy/page_builder/layout/preview.html
+++ b/widgy/contrib/widgy_mezzanine/templates/widgy/page_builder/layout/preview.html
@@ -1,0 +1,7 @@
+{% extends "widgy/preview.html" %}
+{% load i18n %}
+{% load url from future %}
+{% block title %}
+  {{ block.super }}
+  <a class="preview" target="_blank" href="{% url 'widgy.contrib.widgy_mezzanine.views.preview' node_pk=self.node.pk %}">{% trans "Preview" %}</a>
+{% endblock %}

--- a/widgy/contrib/widgy_mezzanine/templates/widgy/versioned_widgy_field.html
+++ b/widgy/contrib/widgy_mezzanine/templates/widgy/versioned_widgy_field.html
@@ -1,7 +1,0 @@
-{% extends "widgy/versioned_widgy_field_base.html" %}
-{% load url from future %}
-{% load i18n %}
-{% block widgy_tools %}
-{{ block.super }}
-  <li><a class="preview" target="_blank" href="{% url 'widgy.contrib.widgy_mezzanine.views.preview' node_pk=node.pk %}">{% trans "Preview" %}</a></li>
-{% endblock %}

--- a/widgy/static/widgy/css/tabbed.scss
+++ b/widgy/static/widgy/css/tabbed.scss
@@ -6,6 +6,10 @@
     .delete span {
       display: none;
     }
+
+    .preview {
+      display: inline;
+    }
   }
 
   .preview,


### PR DESCRIPTION
I need this because in widgy_i18n, I have more than one layout per page
and I need to be able to have more than one preview button.  This is a
little ugly actually, but nothing that can't be fixed.
