### PR TITLE
Optimize prefetch_tree by skipping boring models

### DIFF
--- a/tests/modeltests/core_tests/models.py
+++ b/tests/modeltests/core_tests/models.py
@@ -60,6 +60,9 @@ class CantGoAnywhereWidget(Content):
         return False
 
 
+# this intentially uses multi-table inheritance instead of proxying, see
+# TestCore.test_to_json_works_for_multi_table_inheritance and
+# TestCore.test_interesting_fields.
 class PickyBucket(Bucket):
     def valid_parent_of(self, cls, obj=None):
         if obj:


### PR DESCRIPTION
This is a weird one. We can save a lot of queries during prefetching by skipping models without any fields.

A model is 'boring' if its pk is its only field. Widgy creates lots of these, because there are many container widgets that have no data, like Layout, Bucket, FormHeader, etc.

For boring models, we don't need to go to the database while prefetching because they don't have any data! We can just instantiate them with their pk. This might break something while saving -- I think it will change the behavior of `Model._state.adding`, and I'm not sure how that actually works.

There's a way to take this even further -- get rid of the boring tables altogether and leave `Node.content_id` NULL for boring models. This would speed up tree cloning too, because lots of boring queries are wasted to duplicate each boring model.
