### PR TITLE
Integrate the NodeEditView better with the admin center

### DIFF
--- a/widgy/templates/widgy/views/edit_node.html
+++ b/widgy/templates/widgy/views/edit_node.html
@@ -1,14 +1,14 @@
-<!doctype html>{% load fusionbox_tags %}
-<html>
-  <head>
-    <title>Edit Node</title>
-  </head>
-  <body class="popOut">
-    {% include "widgy/widgy_field.html" %}
-    <script>
-      require(['widgy'], function(Widgy) {
-        Widgy.actAsPopOut();
-      });
-    </script>
-  </body>
-</html>
+{% extends "admin/change_form.html" %}
+{% load i18n %}
+
+{% block title %}{% trans 'Edit Node' %}{{ block.super }}{% endblock %}
+{% block bodyclass %}popOut{% endblock %}
+
+{% block content %}
+{% include "widgy/widgy_field.html" %}
+<script>
+  require(['widgy'], function(Widgy) {
+    Widgy.actAsPopOut();
+  });
+</script>
+{% endblock %}

--- a/widgy/views/api.py
+++ b/widgy/views/api.py
@@ -204,12 +204,34 @@ class NodeEditView(WidgyViewMixin, NodeSingleObjectMixin, DetailView):
 
     template_name = 'widgy/views/edit_node.html'
 
+    def get_media(self):
+        # TODO: don't copy this directly from ModelAdmin.  Either figure out
+        # how to use that implementation or figure something else out.  This is
+        # currently necessary to support things like the
+        # RelatedFieldWidgetWrapper (and I suspect also filer's widgets).
+        #
+        # Doing this is very admin-oriented, we would have to rethink this for
+        # frontend widgy editing.
+        from django.contrib.admin.templatetags.admin_static import static
+        from django.conf import settings
+        from django import forms
+        extra = '' if settings.DEBUG else '.min'
+        js = [
+            'core.js',
+            'admin/RelatedObjectLookups.js',
+            'jquery%s.js' % extra,
+            'jquery.init.js'
+        ]
+        return forms.Media(js=[static('admin/js/%s' % url) for url in js])
+
     def get_context_data(self, **kwargs):
         kwargs = super(NodeEditView, self).get_context_data(**kwargs)
         kwargs.update(
             html_id='node_%s' % (self.object.pk),
             node_dict=self.object.to_json(self.site),
             api_url=reverse(self.site.node_view),
+            is_popup=True,
+            media=self.get_media(),
         )
         return kwargs
 


### PR DESCRIPTION
This fixes the problem where widgets that rely on admin center
JavaScript code (for example the RelatedFieldWidgetWrapper) break when
in a popOut.

However, this makes the NodeEditView admin-centric.
