### PR TITLE
Widgets should be able to reference other widgets in their tree

### DIFF
--- a/widgy/contrib/form_builder/migrations/0010_auto__add_field_emailuserhandler_to_ident__chg_field_formsubmission_cr.py
+++ b/widgy/contrib/form_builder/migrations/0010_auto__add_field_emailuserhandler_to_ident__chg_field_formsubmission_cr.py
@@ -1,0 +1,152 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'EmailUserHandler.to_ident'
+        db.add_column('form_builder_emailuserhandler', 'to_ident',
+                      self.gf('django.db.models.fields.CharField')(default='', max_length=36),
+                      keep_default=False)
+
+
+        # Changing field 'FormSubmission.created_at'
+        db.alter_column('form_builder_formsubmission', 'created_at', self.gf('django.db.models.fields.DateTimeField')(auto_now_add=True))
+
+    def backwards(self, orm):
+        # Deleting field 'EmailUserHandler.to_ident'
+        db.delete_column('form_builder_emailuserhandler', 'to_ident')
+
+
+        # Changing field 'FormSubmission.created_at'
+        db.alter_column('form_builder_formsubmission', 'created_at', self.gf('django.db.models.fields.DateTimeField')())
+
+    models = {
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'form_builder.choicefield': {
+            'Meta': {'object_name': 'ChoiceField'},
+            'choices': ('django.db.models.fields.TextField', [], {}),
+            'help_text': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ident': ('django.db.models.fields.CharField', [], {'max_length': '36', 'blank': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'required': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '25'})
+        },
+        'form_builder.emailsuccesshandler': {
+            'Meta': {'object_name': 'EmailSuccessHandler'},
+            'content': ('widgy.contrib.page_builder.db.fields.MarkdownField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'subject': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'to': ('django.db.models.fields.EmailField', [], {'max_length': '75'})
+        },
+        'form_builder.emailuserhandler': {
+            'Meta': {'object_name': 'EmailUserHandler'},
+            'content': ('widgy.contrib.page_builder.db.fields.MarkdownField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'subject': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'to': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'+'", 'null': 'True', 'to': "orm['widgy.Node']"}),
+            'to_ident': ('django.db.models.fields.CharField', [], {'max_length': '36'})
+        },
+        'form_builder.form': {
+            'Meta': {'object_name': 'Form'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ident': ('django.db.models.fields.CharField', [], {'max_length': '36', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'default': "u'Untitled form 8'", 'max_length': '255'})
+        },
+        'form_builder.formbody': {
+            'Meta': {'object_name': 'FormBody'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'form_builder.forminput': {
+            'Meta': {'object_name': 'FormInput'},
+            'help_text': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ident': ('django.db.models.fields.CharField', [], {'max_length': '36', 'blank': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'required': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        'form_builder.formmeta': {
+            'Meta': {'object_name': 'FormMeta'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'form_builder.formsubmission': {
+            'Meta': {'object_name': 'FormSubmission'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'form_ident': ('django.db.models.fields.CharField', [], {'max_length': '36'}),
+            'form_node': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'form_submissions'", 'on_delete': 'models.PROTECT', 'to': "orm['widgy.Node']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'})
+        },
+        'form_builder.formvalue': {
+            'Meta': {'object_name': 'FormValue'},
+            'field_ident': ('django.db.models.fields.CharField', [], {'max_length': '36'}),
+            'field_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'field_node': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['widgy.Node']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'submission': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'values'", 'to': "orm['form_builder.FormSubmission']"}),
+            'value': ('django.db.models.fields.TextField', [], {})
+        },
+        'form_builder.multiplechoicefield': {
+            'Meta': {'object_name': 'MultipleChoiceField'},
+            'choices': ('django.db.models.fields.TextField', [], {}),
+            'help_text': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ident': ('django.db.models.fields.CharField', [], {'max_length': '36', 'blank': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'required': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '25'})
+        },
+        'form_builder.savedatahandler': {
+            'Meta': {'object_name': 'SaveDataHandler'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'form_builder.submitbutton': {
+            'Meta': {'object_name': 'SubmitButton'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'text': ('django.db.models.fields.CharField', [], {'default': "u'submit'", 'max_length': '255'})
+        },
+        'form_builder.successhandlers': {
+            'Meta': {'object_name': 'SuccessHandlers'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'form_builder.successmessagebucket': {
+            'Meta': {'object_name': 'SuccessMessageBucket'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'form_builder.textarea': {
+            'Meta': {'object_name': 'Textarea'},
+            'help_text': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ident': ('django.db.models.fields.CharField', [], {'max_length': '36', 'blank': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'required': ('django.db.models.fields.BooleanField', [], {'default': 'True'})
+        },
+        'form_builder.uncaptcha': {
+            'Meta': {'object_name': 'Uncaptcha'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'widgy.node': {
+            'Meta': {'object_name': 'Node'},
+            'content_id': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'depth': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_frozen': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'numchild': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'path': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'})
+        }
+    }
+
+    complete_apps = ['form_builder']

--- a/widgy/contrib/form_builder/migrations/0011_populate_to_ident.py
+++ b/widgy/contrib/form_builder/migrations/0011_populate_to_ident.py
@@ -1,0 +1,185 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import DataMigration
+from django.db import models
+from django.core.exceptions import ObjectDoesNotExist
+
+
+def get_ancestors(orm, node):
+    """
+    copied from Treebeard
+    """
+    paths = [node.path[0:pos]
+             for pos in range(0, len(node.path), 4)[1:]]
+    return orm['widgy.Node'].objects.filter(path__in=paths).order_by('depth')
+
+
+def get_children(orm, node):
+    return orm['widgy.Node'].objects.filter(path__startswith=node.path).order_by('depth')
+
+
+def get_content(orm, node):
+    ct = orm['contenttypes.ContentType'].objects.get(pk=node.content_type_id)
+    return orm['%s.%s' % (ct.app_label, ct.model)].objects.get(pk=node.content_id)
+
+
+def get_node(orm, content):
+    ct = orm['contenttypes.ContentType'].objects.get(app_label=content._meta.app_label, model=content._meta.module_name)
+    return orm['widgy.Node'].objects.get(content_type_id=ct.pk, content_id=content.pk)
+
+
+class Migration(DataMigration):
+
+    def forwards(self, orm):
+        "Write your forwards methods here."
+        # Note: Remember to use orm['appname.ModelName'] rather than "from appname.models..."
+        for h in orm['form_builder.EmailUserHandler'].objects.filter(to__isnull=False):
+            try:
+                h.to
+            except ObjectDoesNotExist:
+                pass
+            else:
+                h.to_ident = get_content(orm, h.to).ident
+                h.save()
+
+    def backwards(self, orm):
+        "Write your backwards methods here."
+        for h in orm['form_builder.EmailUserHandler'].objects.exclude(to_ident=''):
+            handler_node = get_node(orm, h)
+            form_ct = orm['contenttypes.ContentType'].objects.get(app_label='form_builder', model='form')
+            form_node = get_ancestors(orm, handler_node).get(content_type_id=form_ct.pk)
+            forminput_ct = orm['contenttypes.ContentType'].objects.get(app_label='form_builder', model='forminput')
+            for child in get_children(orm, form_node):
+                if child.content_type_id == forminput_ct.pk:
+                    forminput = get_content(orm, child)
+                    if forminput.ident == h.to_ident:
+                        h.to = child
+            h.save()
+
+    models = {
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'form_builder.choicefield': {
+            'Meta': {'object_name': 'ChoiceField'},
+            'choices': ('django.db.models.fields.TextField', [], {}),
+            'help_text': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ident': ('django.db.models.fields.CharField', [], {'max_length': '36', 'blank': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'required': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '25'})
+        },
+        'form_builder.emailsuccesshandler': {
+            'Meta': {'object_name': 'EmailSuccessHandler'},
+            'content': ('widgy.contrib.page_builder.db.fields.MarkdownField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'subject': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'to': ('django.db.models.fields.EmailField', [], {'max_length': '75'})
+        },
+        'form_builder.emailuserhandler': {
+            'Meta': {'object_name': 'EmailUserHandler'},
+            'content': ('widgy.contrib.page_builder.db.fields.MarkdownField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'subject': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'to': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'+'", 'null': 'True', 'to': "orm['widgy.Node']"}),
+            'to_ident': ('django.db.models.fields.CharField', [], {'max_length': '36'})
+        },
+        'form_builder.form': {
+            'Meta': {'object_name': 'Form'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ident': ('django.db.models.fields.CharField', [], {'max_length': '36', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'default': "u'Untitled form 8'", 'max_length': '255'})
+        },
+        'form_builder.formbody': {
+            'Meta': {'object_name': 'FormBody'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'form_builder.forminput': {
+            'Meta': {'object_name': 'FormInput'},
+            'help_text': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ident': ('django.db.models.fields.CharField', [], {'max_length': '36', 'blank': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'required': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        'form_builder.formmeta': {
+            'Meta': {'object_name': 'FormMeta'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'form_builder.formsubmission': {
+            'Meta': {'object_name': 'FormSubmission'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'form_ident': ('django.db.models.fields.CharField', [], {'max_length': '36'}),
+            'form_node': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'form_submissions'", 'on_delete': 'models.PROTECT', 'to': "orm['widgy.Node']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'})
+        },
+        'form_builder.formvalue': {
+            'Meta': {'object_name': 'FormValue'},
+            'field_ident': ('django.db.models.fields.CharField', [], {'max_length': '36'}),
+            'field_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'field_node': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['widgy.Node']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'submission': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'values'", 'to': "orm['form_builder.FormSubmission']"}),
+            'value': ('django.db.models.fields.TextField', [], {})
+        },
+        'form_builder.multiplechoicefield': {
+            'Meta': {'object_name': 'MultipleChoiceField'},
+            'choices': ('django.db.models.fields.TextField', [], {}),
+            'help_text': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ident': ('django.db.models.fields.CharField', [], {'max_length': '36', 'blank': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'required': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '25'})
+        },
+        'form_builder.savedatahandler': {
+            'Meta': {'object_name': 'SaveDataHandler'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'form_builder.submitbutton': {
+            'Meta': {'object_name': 'SubmitButton'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'text': ('django.db.models.fields.CharField', [], {'default': "u'submit'", 'max_length': '255'})
+        },
+        'form_builder.successhandlers': {
+            'Meta': {'object_name': 'SuccessHandlers'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'form_builder.successmessagebucket': {
+            'Meta': {'object_name': 'SuccessMessageBucket'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'form_builder.textarea': {
+            'Meta': {'object_name': 'Textarea'},
+            'help_text': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ident': ('django.db.models.fields.CharField', [], {'max_length': '36', 'blank': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'required': ('django.db.models.fields.BooleanField', [], {'default': 'True'})
+        },
+        'form_builder.uncaptcha': {
+            'Meta': {'object_name': 'Uncaptcha'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'widgy.node': {
+            'Meta': {'object_name': 'Node'},
+            'content_id': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'depth': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_frozen': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'numchild': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'path': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'})
+        }
+    }
+
+    complete_apps = ['form_builder']
+    symmetrical = True

--- a/widgy/contrib/form_builder/migrations/0012_auto__del_field_emailuserhandler_to.py
+++ b/widgy/contrib/form_builder/migrations/0012_auto__del_field_emailuserhandler_to.py
@@ -1,0 +1,145 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Deleting field 'EmailUserHandler.to'
+        db.delete_column('form_builder_emailuserhandler', 'to_id')
+
+
+    def backwards(self, orm):
+        # Adding field 'EmailUserHandler.to'
+        db.add_column('form_builder_emailuserhandler', 'to',
+                      self.gf('django.db.models.fields.related.ForeignKey')(related_name=u'+', null=True, to=orm['widgy.Node']),
+                      keep_default=False)
+
+
+    models = {
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'form_builder.choicefield': {
+            'Meta': {'object_name': 'ChoiceField'},
+            'choices': ('django.db.models.fields.TextField', [], {}),
+            'help_text': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ident': ('django.db.models.fields.CharField', [], {'max_length': '36', 'blank': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'required': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '25'})
+        },
+        'form_builder.emailsuccesshandler': {
+            'Meta': {'object_name': 'EmailSuccessHandler'},
+            'content': ('widgy.contrib.page_builder.db.fields.MarkdownField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'subject': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'to': ('django.db.models.fields.EmailField', [], {'max_length': '75'})
+        },
+        'form_builder.emailuserhandler': {
+            'Meta': {'object_name': 'EmailUserHandler'},
+            'content': ('widgy.contrib.page_builder.db.fields.MarkdownField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'subject': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'to_ident': ('django.db.models.fields.CharField', [], {'max_length': '36'})
+        },
+        'form_builder.form': {
+            'Meta': {'object_name': 'Form'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ident': ('django.db.models.fields.CharField', [], {'max_length': '36', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'default': "u'Untitled form 8'", 'max_length': '255'})
+        },
+        'form_builder.formbody': {
+            'Meta': {'object_name': 'FormBody'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'form_builder.forminput': {
+            'Meta': {'object_name': 'FormInput'},
+            'help_text': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ident': ('django.db.models.fields.CharField', [], {'max_length': '36', 'blank': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'required': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        'form_builder.formmeta': {
+            'Meta': {'object_name': 'FormMeta'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'form_builder.formsubmission': {
+            'Meta': {'object_name': 'FormSubmission'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'form_ident': ('django.db.models.fields.CharField', [], {'max_length': '36'}),
+            'form_node': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'form_submissions'", 'on_delete': 'models.PROTECT', 'to': "orm['widgy.Node']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'})
+        },
+        'form_builder.formvalue': {
+            'Meta': {'object_name': 'FormValue'},
+            'field_ident': ('django.db.models.fields.CharField', [], {'max_length': '36'}),
+            'field_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'field_node': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['widgy.Node']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'submission': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'values'", 'to': "orm['form_builder.FormSubmission']"}),
+            'value': ('django.db.models.fields.TextField', [], {})
+        },
+        'form_builder.multiplechoicefield': {
+            'Meta': {'object_name': 'MultipleChoiceField'},
+            'choices': ('django.db.models.fields.TextField', [], {}),
+            'help_text': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ident': ('django.db.models.fields.CharField', [], {'max_length': '36', 'blank': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'required': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '25'})
+        },
+        'form_builder.savedatahandler': {
+            'Meta': {'object_name': 'SaveDataHandler'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'form_builder.submitbutton': {
+            'Meta': {'object_name': 'SubmitButton'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'text': ('django.db.models.fields.CharField', [], {'default': "u'submit'", 'max_length': '255'})
+        },
+        'form_builder.successhandlers': {
+            'Meta': {'object_name': 'SuccessHandlers'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'form_builder.successmessagebucket': {
+            'Meta': {'object_name': 'SuccessMessageBucket'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'form_builder.textarea': {
+            'Meta': {'object_name': 'Textarea'},
+            'help_text': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ident': ('django.db.models.fields.CharField', [], {'max_length': '36', 'blank': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'required': ('django.db.models.fields.BooleanField', [], {'default': 'True'})
+        },
+        'form_builder.uncaptcha': {
+            'Meta': {'object_name': 'Uncaptcha'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'widgy.node': {
+            'Meta': {'object_name': 'Node'},
+            'content_id': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'depth': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_frozen': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'numchild': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'path': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'})
+        }
+    }
+
+    complete_apps = ['form_builder']

--- a/widgy/models/base.py
+++ b/widgy/models/base.py
@@ -25,6 +25,7 @@ from widgy.exceptions import (
     ParentChildRejection,
     RootDisplacementError
 )
+from widgy.signals import pre_delete_widget
 from widgy.generic import WidgyGenericForeignKey, ProxyGenericRelation
 from widgy.utils import exception_to_bool, update_context
 
@@ -724,16 +725,9 @@ class Content(models.Model):
         else:
             assert right or parent
 
-    def pre_delete(self):
-        """
-        Called right before deletion, when our node still exists.
-        """
-        pass
-
     def delete(self, raw=False):
         self.check_frozen()
-        if not raw:
-            self.pre_delete()
+        pre_delete_widget.send(self.__class__, instance=self, raw=raw)
         self.node.delete()
         super(Content, self).delete()
 

--- a/widgy/signals.py
+++ b/widgy/signals.py
@@ -1,0 +1,4 @@
+from django.dispatch import Signal
+
+
+pre_delete_widget = Signal(providing_args=['instance', 'raw'])

--- a/widgy/views/api.py
+++ b/widgy/views/api.py
@@ -9,7 +9,7 @@ from django.shortcuts import get_object_or_404
 from django.contrib.contenttypes.models import ContentType
 from django.views.generic import DetailView
 from django.views.generic.detail import SingleObjectMixin
-from django.db.models import get_model
+from django.db.models import get_model, ProtectedError
 
 from fusionbox.views.rest import RestView
 
@@ -143,9 +143,11 @@ class NodeView(WidgyView):
         if not node.content.deletable:
             raise InvalidTreeMovement({'message': "You can't delete me"})
 
-        node.content.delete()
-
-        return self.render_as_node(None)
+        try:
+            node.content.delete()
+            return self.render_as_node(None)
+        except ProtectedError as e:
+            raise ValidationError({'message': e.args[0]})
 
     def options(self, request, node_pk=None):
         response = super(NodeView, self).options(request, node_pk)


### PR DESCRIPTION
We have a `EmailUserHandler` form success handler that sends an email to the person who submitted a form. To know what email address to send to, `EmailUserHandler` currently has a foreign key to a `Node`, another widget in its tree. The `Node` is a `FormInput` widget that specifies which field to get the email address out of.

Versioning breaks this structure. When the tree is committed, the foreign key points to the old widget, not the cloned one in the new tree.

I have two ideas. 
### 1.

`Node` would have two extra fields. `logical_ident` is a UUID field that associates different versions of the same logical widget across versions. When cloning, `logical_ident` stays the same. `version_id` is the ID of the VersionCommit that owns this tree. It is updated for every new version during cloning.

EmailUserHandler would then be able to have a composite foriegn key to another widget in the same version

```
Node
----
logical_ident (UUID)
version_id (FKEY VersionCommit)
((logical_ident, version_id) is a candidate key)
```

```
EmailUserHandler
----------------
logical_ident (UUID)
version_id (FKEY VersionCommit)
email_field_ident (UUID)
# the email field
(email_field_ident, version_id) FKEY (Node.logical_ident, Node.version_id)
# the our node, to enforce uniqueness
(logical_ident, version_id) FKEY (Node.logical_ident, Node.version_id)
```
### 2.

Widgets could get a chance to update their foreign keys during cloning.  They would need to somehow get access to the new version of their related objects. I'm not really sure how this would work. There could be some kind of map from old object to new object that gets passed to `clone()`.
## Priority note

`EmailUserHandler` is broken right now because of this, so some solution for at least its case is needed in the near future.
