### PR TITLE
SelectRelatedManager -- always call select_related

### DIFF
--- a/widgy/contrib/page_builder/models.py
+++ b/widgy/contrib/page_builder/models.py
@@ -20,7 +20,7 @@ from widgy.db.fields import WidgyField
 from widgy.contrib.page_builder.db.fields import MarkdownField, VideoField
 from widgy.contrib.page_builder.forms import CKEditorField
 from widgy.signals import pre_delete_widget
-from widgy.utils import build_url
+from widgy.utils import build_url, SelectRelatedManager
 import widgy
 
 
@@ -165,6 +165,8 @@ class CalloutWidget(Content):
 
     editable = True
 
+    objects = SelectRelatedManager(select_related=['callout__root_node'])
+
     @classmethod
     def valid_child_of(cls, parent, obj=None):
         return isinstance(parent, Sidebar)
@@ -258,6 +260,8 @@ class Image(Content):
     editable = True
 
     image = ImageField()
+
+    objects = SelectRelatedManager(select_related=['image'])
 
     class Meta:
         verbose_name = _('image')

--- a/widgy/utils.py
+++ b/widgy/utils.py
@@ -9,6 +9,7 @@ from contextlib import contextmanager
 from django.utils.html import conditional_escape
 from django.utils.safestring import mark_safe
 from django.template import Context
+from django.db import models
 
 try:
     from django.contrib.auth import get_user_model
@@ -129,3 +130,17 @@ def unique_everseen(iterable, key=None):
             if k not in seen:
                 seen_add(k)
                 yield element
+
+
+class SelectRelatedManager(models.Manager):
+    """
+    A Manager that always uses select_related.
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.select_related = kwargs.pop('select_related', [])
+        super(SelectRelatedManager, self).__init__(*args, **kwargs)
+
+    def get_query_set(self, *args, **kwargs):
+        qs = super(SelectRelatedManager, self).get_query_set(*args, **kwargs)
+        return qs.select_related(*self.select_related)


### PR DESCRIPTION
Widgets that have ForeignKeys should use select_related during tree
prefetching. This manager makes it easy.

Does the manager belong in widgy core? It's only needed by page_builder right now, but it could be useful in other apps too. If it does go in core, what module?
