### PR TITLE
Render caching

### DIFF
--- a/widgy/contrib/form_builder/models.py
+++ b/widgy/contrib/form_builder/models.py
@@ -22,6 +22,7 @@ from widgy.utils import update_context, build_url
 from widgy.contrib.page_builder.db.fields import MarkdownField
 from widgy.contrib.page_builder.models import Bucket, Html
 from widgy.contrib.page_builder.forms import MiniCKEditorField
+from widgy.exceptions import CannotBeCached
 import widgy
 
 

--- a/widgy/contrib/page_builder/models.py
+++ b/widgy/contrib/page_builder/models.py
@@ -158,6 +158,9 @@ class Callout(models.Model):
         verbose_name = _('callout')
         verbose_name_plural = _('callouts')
 
+    def get_cache_key(self, widgy_env, context):
+        return widgy_env['parent']['owner'].get_cache_key(widgy_env, context)
+
 
 @widgy.register
 class CalloutWidget(Content):

--- a/widgy/contrib/widgy_mezzanine/mixins.py
+++ b/widgy/contrib/widgy_mezzanine/mixins.py
@@ -1,6 +1,7 @@
 from django.core import urlresolvers
 
 from widgy.models.links import LinkableMixin
+from widgy.exceptions import CannotBeCached
 
 
 class WidgyPageMixin(LinkableMixin):
@@ -23,3 +24,14 @@ class WidgyPageMixin(LinkableMixin):
                 'form_node_pk': form.node.pk,
                 'root_node_pk': widgy['root_node'].pk,
             })
+
+    def get_cache_key(self, widgy_env, context):
+        request = context.get('request')
+
+        if request and request.method != 'GET':
+            raise CannotBeCached
+
+        return ':'.join([
+            self.title,
+            (request and request.get_full_path()) or self.get_absolute_url()
+        ])

--- a/widgy/exceptions.py
+++ b/widgy/exceptions.py
@@ -47,3 +47,11 @@ class MutualRejection(ParentWasRejected, ChildWasRejected):
     For instances where both child and parent reject the movement request.
     """
     message = "Neither the parent or child accept this parent-child relationship."
+
+
+class CannotBeCached(Exception):
+    """
+    Any widget can prevent the entire tree from being cached by raising
+    this exception.
+    """
+    pass

--- a/widgy/migrations/0010_auto__add_field_node__cache_key.py
+++ b/widgy/migrations/0010_auto__add_field_node__cache_key.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Node._cache_key'
+        db.add_column('widgy_node', '_cache_key',
+                      self.gf('django.db.models.fields.CharField')(max_length=64, null=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Node._cache_key'
+        db.delete_column('widgy_node', '_cache_key')
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'widgy.node': {
+            'Meta': {'unique_together': "[('content_type', 'content_id')]", 'object_name': 'Node'},
+            '_cache_key': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True'}),
+            'content_id': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'depth': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_frozen': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'numchild': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'path': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'})
+        },
+        'widgy.unknownwidget': {
+            'Meta': {'object_name': 'UnknownWidget', 'managed': 'False'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'widgy.versioncommit': {
+            'Meta': {'object_name': 'VersionCommit'},
+            'author': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['widgy.VersionCommit']", 'null': 'True', 'on_delete': 'models.PROTECT'}),
+            'publish_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'root_node': ('widgy.db.fields.WidgyField', [], {'to': "orm['widgy.Node']", 'null': 'True', 'on_delete': 'models.PROTECT', 'blank': 'True'}),
+            'tracker': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'commits'", 'to': "orm['widgy.VersionTracker']"})
+        },
+        'widgy.versiontracker': {
+            'Meta': {'object_name': 'VersionTracker'},
+            'head': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['widgy.VersionCommit']", 'null': 'True', 'on_delete': 'models.PROTECT'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'working_copy': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['widgy.Node']", 'on_delete': 'models.PROTECT'})
+        }
+    }
+
+    complete_apps = ['widgy']

--- a/widgy/signals.py
+++ b/widgy/signals.py
@@ -2,3 +2,5 @@ from django.dispatch import Signal
 
 
 pre_delete_widget = Signal(providing_args=['instance', 'raw'])
+
+tree_changed = Signal(providing_args=["node", "content"])


### PR DESCRIPTION
In the `cache` branch (35d6a6b4). There's the start of some caching machinery. I don't think timestamps are the right way to generate cache keys. Widgets must be able to opt out of caching (current user 'hello' widget), which means none of its ancestors may be cached either. Also, all nodes and contents must be fetched anyway, so we're really only saving template rendering time.

The better way to do this is to store a cache key (not timestamp) on the root `Node`. Whenever the tree is updated, `root_node.update_cache_key()` should be called. `update_cache_key` looks something like:

``` python
class Node(models.Model):
    _cache_key = models.CharField(max_length=64, null=True)
    def update_cache_key(self):
        try:
            cache_keys = [node.content.get_cache_key()
                            for node in self.depth_first_order()]
            self._cache_key = sha256(':'.join(cache_keys))
        except CannotBeCached:
            # Any widget can prevent the entire tree from being cached
            # by raising this exception.
            self._cache_key = None

```

When rendering a tree, the root node is fetched first. The cache is checked _before_ `prefetch_tree` is called. If the node is not cached, `prefetch_tree` happens and rendering proceeds as usual and the result is stored in the cache if the node allows it (_cache_key is not None).

The `tree_changed` signal has the wrong semantics for this. I think the signal should only be fired a single time for one move. This means we need to pass information about the previous state (like parent and right, perhaps) to the signal so it knows where the widget was moved from.
