### PR TITLE
rm unused 'meta' function

### DIFF
--- a/widgy/models/base.py
+++ b/widgy/models/base.py
@@ -525,10 +525,6 @@ class Content(models.Model):
         parent = self.node.get_parent()
         return parent and parent.content
 
-
-    def meta(self):
-        return self._meta
-
     def get_form_class(self, request):
         defaults = {
             "form": self.form,


### PR DESCRIPTION
Anyone know why this is here? I don't think it's used anywhere.
