### PR TITLE
working on drop targets that do not move

### DIFF
--- a/widgy/static/widgy/css/widgy.scss
+++ b/widgy/static/widgy/css/widgy.scss
@@ -166,28 +166,43 @@ textarea {
 li.node_drop_target {
   @include rounded(3px);
   @include transition;
-  border: 1px dashed lighten($green,10%) !important;
+
+  border: none !important;
   background: lighten($green,25%) !important;
   font-size: 1.0em !important;
   font-style: italic !important;
-  height: auto !important;
-  margin: 0.75em 1em !important;
-  padding: 0.25em !important;
+  height: 1em !important;
+  margin: -1em 1em !important;
+  padding: 0em !important;
   text-align: center;
-  
+
   span {
     display: none;
+  }
+
+  &:first-child {
+    margin-top: 0 !important;
+  }
+
+  &:last-child,
+  &.previous.nm {
+    margin-bottom: 0 !important;
   }
 
   &.active {
     border: 1px dashed $green !important;
     background: lighten($green,40%) !important;
     color: darken($green,10%) !important;
-    margin: 0.25em 1em !important;
-    
+    height: 3em !important;
+    padding: 1em !important;
+
     span {
       display: block;
     }
+  }
+
+  &.previous {
+    background: #FF9900 !important;
   }
 }
 
@@ -235,7 +250,6 @@ li.node_drop_target {
     // drag & drop styles
     &.being_dragged {
       @include shadow(#999999, 2px, 2px, 5px);
-      background-color: blue;
       margin: 0 !important;
       position: fixed;
     }

--- a/widgy/static/widgy/js/nodes/nodes.js
+++ b/widgy/static/widgy/js/nodes/nodes.js
@@ -298,22 +298,32 @@ define([ 'exports', 'jquery', 'underscore', 'widgy.backbone', 'lib/q', 'shelves/
         });
       }
 
-      if (this.canAcceptChild(view))
-      {
-        $children.prepend(this.createDropTarget().el);
+      if (this.canAcceptChild(view)) {
+        $children.prepend(this.createDropTarget(view).el);
         this.list.each(function(node_view) {
-          var drop_target = that.createDropTarget().$el.insertAfter(node_view.el);
-
-          if ( mine && view == node_view )
-            drop_target.hide();
-        });
+          var drop_target = that.createDropTarget(view).$el.insertAfter(node_view.el);
+        }, this);
       }
     },
 
-    createDropTarget: function() {
+    createDropTarget: function(view) {
       var drop_target = new DropTargetView();
       drop_target.on('dropped', this.dropChildView);
       this.drop_targets_list.push(drop_target);
+
+      if ( this.list.contains(view) ) {
+        var view_index = this.list.list.indexOf(view),
+            target_index = this.drop_targets_list.list.length - 1;
+        if ( view_index == target_index ) {
+          drop_target.activate().$el
+            .addClass('previous')
+            .attr('style', function(i, s) { return (s||'') + ' height: '+ view.$el.height() +'px !important;'; });
+          if ( view_index == this.list.list.length - 1 )
+            drop_target.$el.addClass('nm');
+        } else if ( view_index == target_index - 1 ) {
+          drop_target.$el.hide();
+        }
+      }
 
       return drop_target.render();
     },
@@ -549,9 +559,10 @@ define([ 'exports', 'jquery', 'underscore', 'widgy.backbone', 'lib/q', 'shelves/
           'opacity': 0,
           'width': '100%',
           'height': '100%',
+          'padding': '20px 40px',
           'position': 'absolute',
-          'top': 0,
-          'left': 0
+          'top': '-20px',
+          'left': '-40px'
         });
       this.$el.prepend($pointerEventsCatcher);
 
@@ -560,10 +571,13 @@ define([ 'exports', 'jquery', 'underscore', 'widgy.backbone', 'lib/q', 'shelves/
 
     activate: function(event) {
       this.$el.addClass('active');
+      return this;
     },
 
     deactivate: function(event) {
-      this.$el.removeClass('active');
+      this.$el.removeClass('active')
+              .css('height', '');
+      return this;
     }
   });
 


### PR DESCRIPTION
This pull request makes the page not jump for many dragging situations when the drop targets appear.  The drop targets attempt to fill the space that was already occupied.

There are certain situations where the page will still jump when drop targets are created.  For example if you have an empty MainContent or empty Sections, they will grow when creating drop targets.

This pull request also improves the drop targets in other ways:
-  more pleasant growing experience
-  lets user know where the widget was picked up from (if it was already in the tree)
-  adds an invisible bumper around the drop targets that allows them to be activated more easily despite their small size.
