### PR TITLE
Optimize

### DIFF
--- a/tests/modeltests/core_tests/tests/api.py
+++ b/tests/modeltests/core_tests/tests/api.py
@@ -79,7 +79,7 @@ class TestApi(RootNodeTestCase, HttpTestCase):
         left, right = make_a_nice_tree(self.root_node, self.widgy_site)
         number_of_nodes = Node.objects.count()
         number_of_right_nodes = len(right.get_descendants()) + 1
-        right_children = right.content.depth_first_order()
+        right_children = list(right.content.depth_first_order())
         r = self.delete(right.get_api_url(self.widgy_site))
         self.assertEqual(r.status_code, 200)
 

--- a/tests/modeltests/core_tests/tests/core.py
+++ b/tests/modeltests/core_tests/tests/core.py
@@ -997,6 +997,14 @@ class TestPrefetchTree(RootNodeTestCase):
             # node.content.node must get set even if node.content has already been accessed
             self.assertEqual(self.root_node.content.node, self.root_node)
 
+    def test_prefetch_tree_on_leaf_node(self):
+        root_node = RawTextWidget.add_root(widgy_site).node
+
+        # A single query to fetch the Content -- don't try to fetch nodes
+        # because we already know we're a leaf.
+        with self.assertNumQueries(1):
+            root_node.prefetch_tree()
+
 
 class TestSite(TestCase):
     def test_scss_location(self):

--- a/tests/modeltests/core_tests/tests/core.py
+++ b/tests/modeltests/core_tests/tests/core.py
@@ -65,6 +65,7 @@ class TestCore(RootNodeTestCase):
             picky_bucket.add_child(widgy_site,
                                    RawTextWidget,
                                    text='aasdf')
+        self.assertEqual(picky_bucket.node.numchild, 0)
 
         picky_bucket.add_child(widgy_site,
                                RawTextWidget,
@@ -73,6 +74,19 @@ class TestCore(RootNodeTestCase):
         with self.assertRaises(ChildWasRejected):
             picky_bucket.add_child(widgy_site,
                                    Layout)
+
+    def test_node_cache(self):
+        picky_bucket = self.root_node.content.add_child(widgy_site, PickyBucket)
+
+        x = picky_bucket.add_child(widgy_site, RawTextWidget, text='hello')
+
+        self.assertEqual(picky_bucket.node.numchild, 1)
+
+        x.add_sibling(widgy_site,
+                      RawTextWidget,
+                      text='hello')
+
+        self.assertEqual(picky_bucket.node.numchild, 2)
 
     def test_to_json_works_for_multi_table_inheritance(self):
         picky_bucket = self.root_node.content.add_child(widgy_site,

--- a/widgy/contrib/page_builder/tests.py
+++ b/widgy/contrib/page_builder/tests.py
@@ -36,7 +36,12 @@ class TestTableWidget(TestCase):
         row_1 = self.table.body.add_child(widgy_site, TableRow)
         row_2 = self.table.body.add_child(widgy_site, TableRow)
 
+        self.assertTrue(row_1.node.is_leaf())
+
         th1 = self.table.header.add_child(widgy_site, TableHeaderData)
+
+        # adding a column to the header needs to add a cell to each row
+        self.assertFalse(row_1.node.is_leaf())
 
         cell_1 = row_1.get_children()[0]
         cell_2 = row_2.get_children()[0]

--- a/widgy/models/base.py
+++ b/widgy/models/base.py
@@ -139,6 +139,14 @@ class Node(MP_Node):
                 return self
         return super(Node, self).get_root()
 
+    def get_descendants(self):
+        if self.is_leaf():
+            # treebeard does a weird useless query:
+            # SELECT * FROM node WHERE id = 12 AND id != 12
+            return self.__class__.objects.none()
+        else:
+            return super(Node, self).get_descendants()
+
     def maybe_prefetch_tree(self):
         """
         Prefetch the tree unless it has already been prefetched

--- a/widgy/models/base.py
+++ b/widgy/models/base.py
@@ -72,6 +72,11 @@ class Node(MP_Node):
     def __unicode__(self):
         return unicode(self.content)
 
+    def is_root(self):
+        # treebeard's implementation of is_root does a query, even though we
+        # already have all the information we need.
+        return self.depth == 1
+
     def to_json(self, site):
         children = [c.to_json(site) for c in self.get_children()]
         json = {
@@ -211,9 +216,7 @@ class Node(MP_Node):
         cls.attach_content_instances(list(itertools.chain(*trees)))
         for tree in trees:
             root_node = tree.pop(0)
-            # This should get_depth() or is_root(), but both of those do
-            # another query
-            if root_node.depth == 1:
+            if root_node.is_root():
                 root_node._parent = None
             root_node.consume_children(tree)
             assert not tree, "all of the nodes should be consumed"


### PR DESCRIPTION
- ContentList -- an optimizing wrapper around a list of Contents
  
  Many operations return a list of Content instances, fetched from a Node queryset. Many common operations on this list only need information in the Node, so it's wasteful to always fetch the Contents.
  
  The optimizations it performs:
  - Prefetches the Content instances in bulk (This was already done since 6549cf3f8)
  - Implements `__contains__` without fetching Contents at all
  - Implements `__len__` without fetching Contents at all
  - Can calculate Content _classes_ with fetching the Content instances
  
  It behaves exactly like a list, so this is backwards compatible. It does have a new public property -- `content_classes` -- which is used to retrieve a list of Content classes when full instances aren't required, such as when you're only doing an `isinstance` check.
- Override treebeard's `is_root` with one that never does a query

Possibly more to come -- I'm working on reducing the number of of times the reverse node relationship (Content.node) query happens.
