### PR TITLE
Unicode support for form CSV export

### DIFF
--- a/widgy/contrib/form_builder/admin.py
+++ b/widgy/contrib/form_builder/admin.py
@@ -54,17 +54,11 @@ class FormAdmin(admin.ModelAdmin):
 
     def download_view(self, request, object_id, *args, **kwargs):
         obj = self.get_object(request, unquote(object_id))
-        resp = HttpResponse(content_type='text/csv')
+        resp = HttpResponse(content_type='text/csv; charset=utf-8')
         resp['Content-Disposition'] = 'attachment; filename="%s"' % self.csv_file_name(obj)
 
-        values = obj.submissions.as_dictionaries()
-        headers = obj.submissions.get_formfield_labels()
+        obj.submissions.to_csv(resp)
 
-        writer = csv.DictWriter(resp, list(headers))
-        writer.writerow(headers)
-
-        for row in values:
-            writer.writerow(row)
         return resp
 
     def submission_count(self, obj):

--- a/widgy/utils.py
+++ b/widgy/utils.py
@@ -36,9 +36,11 @@ except ImportError:
 
 try:
     from django.utils.encoding import force_text
+    from django.utils.encoding import force_bytes
 except ImportError:
     # Django 1.4
-    from django.utils.encoding import force_unicode
+    from django.utils.encoding import force_unicode, smart_str
+    force_bytes = smart_str
     force_text = force_unicode
 
 


### PR DESCRIPTION
Adds a new method, `to_csv`, on the FormSubmission queryset (mostly for testability). It writes its submissions as CSV to a file-like object. It's used in the admin to export submissions as CSV.
