### PR TITLE
Extract the root-node creation into its own method

### DIFF
--- a/tests/modeltests/core_tests/tests/fields.py
+++ b/tests/modeltests/core_tests/tests/fields.py
@@ -53,6 +53,15 @@ class TestWidgyField(TestCase):
         self.assertEqual(len(layout_contenttypes), 1)
         self.assertIn(the_layout_contenttype, layout_contenttypes)
 
+    def test_add_root(self):
+        instance = HasAWidgy()
+        instance.widgy = ContentType.objects.get_for_model(Layout)
+        root_node = HasAWidgy._meta.get_field('widgy').add_root(instance, {
+            'pk': 1337,
+        })
+
+        self.assertEqual(root_node.content.pk, 1337)
+
 class TestPlainForm(TestCase):
     def setUp(self):
         # WidgyForms cannot be at the root level of a test because they make


### PR DESCRIPTION
`WidgyField.pre_save` creates a root node. This patch extracts that creation into a method called `add_root`. This means:
- VersionedWidgyField no longer needs to override `pre_save`, it overrides `add_root`.
- Application developers can call `add_root` themselves and provide `root_content_kwargs` when they need to provide values to create the root node (Like when it has non-null fields).
