### PR TITLE
Delete confirmation improvements

### DIFF
--- a/tests/modeltests/core_tests/models.py
+++ b/tests/modeltests/core_tests/models.py
@@ -33,6 +33,10 @@ class Bucket(Content):
     def render(self, context, template=None):
         return ''.join(i.render(context) for i in self.get_children())
 
+    class Meta:
+        # test that stuff works with lazily translated strings
+        verbose_name = _("bucket")
+
 
 class RawTextWidget(Content):
     text = models.TextField()

--- a/widgy/models/base.py
+++ b/widgy/models/base.py
@@ -453,6 +453,7 @@ class Content(models.Model):
             'shelf': self.shelf,
             'attributes': self.get_attributes(),
             'form_prefix': self.get_form_prefix(),
+            'display_name': self.display_name,
         }
         if self.editable:
             data['edit_url'] = site.reverse(site.node_edit_view, kwargs=node_pk_kwargs)
@@ -478,7 +479,7 @@ class Content(models.Model):
 
     @property
     def display_name(self):
-        return capfirst(self._meta.verbose_name)
+        return unicode(self._meta.verbose_name)
 
     @property
     def class_name(self):

--- a/widgy/static/widgy/css/widgy.scss
+++ b/widgy/static/widgy/css/widgy.scss
@@ -224,6 +224,11 @@ li.node_drop_target {
       cursor: pointer;
     }
 
+    &.deleting * {
+      // fixme!
+      background-color: red;
+    }
+
     // specific node styles
     &.invisible {
       background-color: inherit;

--- a/widgy/static/widgy/js/modal/modal.js
+++ b/widgy/static/widgy/js/modal/modal.js
@@ -68,10 +68,13 @@ define([ 'widgy.backbone',
     }
   }
 
-  function confirm(message, success) {
+  function confirm(message, success, failure) {
     if ( window.confirm(message) ) {
       success();
+    } else if ( failure ) {
+      failure();
     }
+
   }
 
   return {

--- a/widgy/static/widgy/js/nodes/nodes.js
+++ b/widgy/static/widgy/js/nodes/nodes.js
@@ -183,7 +183,14 @@ define([ 'exports', 'jquery', 'underscore', 'widgy.backbone', 'lib/q', 'shelves/
 
     'delete': function(event) {
       // TODO: A better UI experience would be undo, but this is a stop gap.
-      modal.confirm('Are you sure?', this.deleteSelf);
+      this.$el.addClass('deleting');
+      modal.confirm(
+        'Are you sure you want to delete this ' + this.content.get('display_name') + '?',
+        this.deleteSelf,
+        _.bind(function() {
+          this.$el.removeClass('deleting');
+        }, this)
+      );
       return false;
     },
 


### PR DESCRIPTION
- Change the confirmation message to include display_name: 'Are you sure you want to delete this section?'
- Highlight the widgets you will be deleting with the `deleting` CSS class, so you can double check that you have the right one.
