### PR TITLE
Add get_action_links to Widgy owners

### DIFF
--- a/tests/modeltests/core_tests/tests/fields.py
+++ b/tests/modeltests/core_tests/tests/fields.py
@@ -4,6 +4,7 @@ from django.test import TestCase
 from django import forms
 from django.contrib.contenttypes.models import ContentType
 from django.template import Context
+from django.utils import unittest
 
 import mock
 
@@ -62,6 +63,8 @@ class TestWidgyField(TestCase):
 
         self.assertEqual(root_node.content.pk, 1337)
 
+
+@unittest.skip("We want WidgyFields to work with non-modelforms, but we haven't designed an API yet.")
 class TestPlainForm(TestCase):
     def setUp(self):
         # WidgyForms cannot be at the root level of a test because they make
@@ -109,6 +112,7 @@ class TestPlainForm(TestCase):
         # todo...I don't even know what the api for a non-modelform widgy field is
         root_node = Layout.add_root(widgy_site)
         x = self.form(initial={'widgy_field': root_node})
+
 
 class TestModelForm(TestCase):
     def setUp(self):

--- a/widgy/contrib/review_queue/templates/review_queue/commit_preview.html
+++ b/widgy/contrib/review_queue/templates/review_queue/commit_preview.html
@@ -1,5 +1,13 @@
-{% load compress %}
-<iframe src="{{ commit_url }}"></iframe>
+{% load compress widgy_tags %}
+{% for owner in owners %}
+  {% get_action_links owner node as links %}
+  {% for link in links %}
+    {% if link.type == 'preview' %}
+      {{ link.text }}
+      <iframe src="{{ link.url }}"></iframe>
+    {% endif %}
+  {% endfor %}
+{% endfor %}
 {% compress css %}
 <link type="text/x-scss" rel="stylesheet" href="{% static 'widgy/css/unapproved_commits.scss' %}">
 {% endcompress %}

--- a/widgy/contrib/widgy_mezzanine/admin.py
+++ b/widgy/contrib/widgy_mezzanine/admin.py
@@ -18,7 +18,6 @@ from mezzanine.pages.models import Link
 
 from widgy.forms import WidgyFormMixin
 from widgy.contrib.widgy_mezzanine import get_widgypage_model
-from widgy.contrib.widgy_mezzanine.views import get_page_from_node
 from widgy.utils import fancy_import, format_html
 from widgy.models import links
 
@@ -27,19 +26,18 @@ from widgy.contrib.review_queue.admin import VersionCommitAdminBase
 WidgyPage = get_widgypage_model()
 
 
-class GetSiteMixin(object):
-    def get_site(self):
-        return fancy_import(settings.WIDGY_MEZZANINE_SITE)
-
-
 class WidgyPageAdminForm(WidgyFormMixin, PageAdminForm):
     class Meta:
         model = WidgyPage
 
     def __init__(self, *args, **kwargs):
         super(WidgyPageAdminForm, self).__init__(*args, **kwargs)
-        self.fields['publish_date'].help_text = _("If you enter a date here, the page will not be viewable on the site until then")
-        self.fields['expiry_date'].help_text = _("If you enter a date here, the page will not be viewable after this time")
+        self.fields['publish_date'].help_text = _(
+            "If you enter a date here, the page will not be viewable on the site until then"
+        )
+        self.fields['expiry_date'].help_text = _(
+            "If you enter a date here, the page will not be viewable after this time"
+        )
         self.fields['status'].initial = CONTENT_STATUS_DRAFT
 
     def clean_status(self):
@@ -50,16 +48,9 @@ class WidgyPageAdminForm(WidgyFormMixin, PageAdminForm):
         return status
 
 
-class WidgyPageAdmin(PageAdmin, GetSiteMixin):
+class WidgyPageAdmin(PageAdmin):
     change_form_template = 'widgy/page_builder/widgypage_change_form.html'
     form = WidgyPageAdminForm
-
-    def render_change_form(self, request, context, *args, **kwargs):
-        if 'original' in context and context['original'].root_node:
-            # we are rendering a change form
-            obj = context['original']
-            site = self.get_site()
-        return super(WidgyPageAdmin, self).render_change_form(request, context, *args, **kwargs)
 
 
 class UndeleteField(forms.ModelChoiceField):
@@ -133,13 +124,9 @@ class UndeletePage(WidgyPage):
         return super(UndeletePage, self).__init__(*args, **kwargs)
 
 
-class VersionCommitAdmin(GetSiteMixin, VersionCommitAdminBase):
-    def get_commit_name(self, commit):
-        return get_page_from_node(commit.root_node).title
-
-    def get_commit_preview_url(self, commit):
-        return reverse('widgy.contrib.widgy_mezzanine.views.preview',
-                       kwargs={'node_pk': commit.root_node.pk})
+class VersionCommitAdmin(VersionCommitAdminBase):
+    def get_site(self):
+        return fancy_import(settings.WIDGY_MEZZANINE_SITE)
 
 
 # Remove built in Mezzanine models from the admin center

--- a/widgy/contrib/widgy_mezzanine/models.py
+++ b/widgy/contrib/widgy_mezzanine/models.py
@@ -26,8 +26,20 @@ class WidgyPageMixin(object):
             'widgy.contrib.widgy_mezzanine.views.handle_form',
             kwargs={
                 'form_node_pk': form.node.pk,
-                'root_node_pk': widgy['root_node'].pk,
+                'slug': self.slug,
             })
+
+    def get_action_links(self, root_node):
+        return [
+            {
+                'type': 'preview',
+                'text': _('Preview'),
+                'url': urlresolvers.reverse(
+                    'widgy.contrib.widgy_mezzanine.views.preview',
+                    kwargs={'slug': self.slug, 'node_pk': root_node.pk}
+                )
+            },
+        ]
 
     def get_content_model(self):
         """

--- a/widgy/contrib/widgy_mezzanine/templates/widgy/history.html
+++ b/widgy/contrib/widgy_mezzanine/templates/widgy/history.html
@@ -49,10 +49,15 @@
             {% elif can_revert %}
               {% trans "Can't revert; this is the same as the current version." %}
             {% endif %}
-            {% if commit.diff_url %}
-              <a class="button" href="{{ commit.diff_url }}">{% trans "Diff" %}</a>
-            {% endif %}
-            <a class="button" href="{% url 'widgy.contrib.widgy_mezzanine.views.preview' node_pk=commit.root_node.pk %}">{% trans "View" %}</a>
+            {% for diff_url in commit.diff_urls %}
+              <a class="button diff" href="{{ diff_url }}">{% trans "Diff" %}</a>
+            {% endfor %}
+            {% for owner in object.owners %}
+              {% get_action_links owner commit.root_node as links %}
+              {% for link in links %}
+                <a class="button {{ link.type }}" target="_blank" href="{{ link.url }}">{{ link.text }}</a>
+              {% endfor %}
+            {% endfor %}
             {% endblock %}
           </div>
       </div>

--- a/widgy/contrib/widgy_mezzanine/templates/widgy/page_builder/layout/preview.html
+++ b/widgy/contrib/widgy_mezzanine/templates/widgy/page_builder/layout/preview.html
@@ -1,7 +1,0 @@
-{% extends "widgy/preview.html" %}
-{% load i18n %}
-{% load url from future %}
-{% block title %}
-  {{ block.super }}
-  <a class="preview" target="_blank" href="{% url 'widgy.contrib.widgy_mezzanine.views.preview' node_pk=self.node.pk %}">{% trans "Preview" %}</a>
-{% endblock %}

--- a/widgy/contrib/widgy_mezzanine/tests.py
+++ b/widgy/contrib/widgy_mezzanine/tests.py
@@ -7,6 +7,9 @@ from django import forms
 from django.conf import settings
 
 from widgy.site import WidgySite
+from widgy.utils import get_user_model
+
+User = get_user_model()
 widgy_site = WidgySite()
 
 FORM_BUILDER_INSTALLED = 'widgy.contrib.form_builder' in settings.INSTALLED_APPS
@@ -50,6 +53,7 @@ class TestFormHandler(TestCase):
                                                )
 
         req = self.factory.post('/?from=/foo/')
+        req.user = User(is_superuser=True)
 
         with mock.patch.object(Form, 'execute') as form_execute:
             with mock.patch('widgy.contrib.widgy_mezzanine.views.page_view') as page_view:

--- a/widgy/contrib/widgy_mezzanine/urls.py
+++ b/widgy/contrib/widgy_mezzanine/urls.py
@@ -1,6 +1,7 @@
 from django.conf.urls import patterns, url
 
 urlpatterns = patterns('widgy.contrib.widgy_mezzanine.views',
-    url('^preview/(?P<node_pk>[^/]+)/$', 'preview'),
-    url('^form/(?P<form_node_pk>[^/]*)/(?P<root_node_pk>.*)/$', 'handle_form'),
+    url('^preview/(?P<node_pk>[^/]+)/$', 'preview'),  # undelete
+    url('^preview/(?P<node_pk>[^/]+)/(?P<slug>.+)/$', 'preview'),
+    url('^form/(?P<form_node_pk>[^/]*)/(?P<slug>.+)/$', 'handle_form'),
 )

--- a/widgy/site.py
+++ b/widgy/site.py
@@ -47,7 +47,7 @@ class WidgySite(object):
             url('^commit/(?P<pk>[^/]+)/$', self.commit_view),
             url('^history/(?P<pk>[^/]+)/$', self.history_view),
             url('^reset/(?P<pk>[^/]+)/$', self.reset_view),
-            url('^diff/(?P<before_pk>[^/]+)/(?P<after_pk>[^/]+)/$', self.diff_view),
+            url('^diff/$', self.diff_view),
         )
         return urlpatterns
 

--- a/widgy/static/widgy/css/django.fusionbox.scss
+++ b/widgy/static/widgy/css/django.fusionbox.scss
@@ -221,6 +221,7 @@ section.main {
       @include gradient(#eeeeee,#fafafa);
       @include rounded(5px);
       @include shadow($black30,0px,2px,0px);
+      @include clearfix;
       margin: 0px 0px 15px 0px;
       padding: 0px;
       

--- a/widgy/templates/widgy/_commit_form.html
+++ b/widgy/templates/widgy/_commit_form.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load widgy_tags %}
 {% load url from future %}
 <form method="post" class="commit_form" action="{{ action_url }}">
   {% csrf_token %}
@@ -23,11 +24,15 @@
   <p class="submitRow">
     {% block submit_row %}
       <input type="submit" value="{% trans 'Commit' %}">
-      {# TODO: this is dependent on widgy_mezzanine #}
-      <a class="button" target="_blank" href="{% url 'widgy.contrib.widgy_mezzanine.views.preview' node_pk=commit.pk %}">{% trans "Preview" %}</a>
-      {% if diff_url %}
-        <a class="button" target="_blank" href="{{ diff_url }}">{% trans "Diff" %}</a>
-      {% endif %}
+      {% for owner in tracker.owners %}
+        {% get_action_links owner tracker.working_copy as links %}
+        {% for link in links %}
+          <a class="button {{ link.type }}" target="_blank" href="{{ link.url }}">{{ link.text }}</a>
+        {% endfor %}
+      {% endfor %}
+      {% for diff_url in diff_urls %}
+        <a class="button diff" target="_blank" href="{{ diff_url }}">{% trans "Diff" %}</a>
+      {% endfor %}
     {% endblock %}
   </p>
 </form>

--- a/widgy/templates/widgy/commit.html
+++ b/widgy/templates/widgy/commit.html
@@ -5,7 +5,7 @@
 {% block popup-content %}
   {% if changed_anything %}
     {% block commit_form %}
-      {% include "widgy/_commit_form.html" with commit=object.working_copy action_url=commit_url %}
+      {% include "widgy/_commit_form.html" with commit=tracker.working_copy action_url=commit_url %}
     {% endblock %}
   {% else %}
     <p>{% trans "Nothing has changed &mdash; no need to commit." %}</p>

--- a/widgy/templates/widgy/revert.html
+++ b/widgy/templates/widgy/revert.html
@@ -3,5 +3,5 @@
 {% load i18n %}
 
 {% block popup-content %}
-  {% include "widgy/_commit_form.html" with commit=object.root_node action_url=revert_url %}
+  {% include "widgy/_commit_form.html" with commit=tracker.root_node action_url=revert_url %}
 {% endblock %}

--- a/widgy/templates/widgy/versioned_widgy_field_base.html
+++ b/widgy/templates/widgy/versioned_widgy_field_base.html
@@ -1,20 +1,9 @@
 {% extends "widgy/widgy_field.html" %}
-{% load compress static i18n %}
-{% block widgy_container %}
-{% compress css %}
-<link rel="stylesheet" href="{% static 'widgy/fancybox/jquery.fancybox-1.3.4.css' %}">
-<link rel="stylesheet" href="{% static 'widgy/css/django.fusionbox.scss' %}" type="text/x-scss">
-{% endcompress %}
-<ul class="widgy-tools">
-  {% block widgy_tools %}
+{% load i18n %}
+
+{% block widgy_tools %}
   <li><a class="widgy-fancybox commit" href="{{ commit_url }}">{% trans "Commit" %}</a></li>
   <li><a class="widgy-fancybox reset" href="{{ reset_url }}">{% trans "Reset" %}</a></li>
   <li><a class="historylink" target="_blank" href="{{ history_url }}">{% trans "History" %}</a></li>
-  {% endblock %}
-</ul>
-{% compress js %}
-<script src="{% static 'widgy/fancybox/jquery.fancybox-1.3.4.js' %}"></script>
-<script src="{% static 'widgy/js/widgy.admin.js' %}"></script>
-{% endcompress %}
-{{ block.super }}
+  {{ block.super }}
 {% endblock %}

--- a/widgy/templates/widgy/widgy_field.html
+++ b/widgy/templates/widgy/widgy_field.html
@@ -1,4 +1,4 @@
-{% load compress %}{% load fusionbox_tags %}{% load static %}
+{% load compress %}{% load fusionbox_tags %}{% load static %}{% load widgy_tags %}
 {% comment %}
 Hitting return in a form clicks its first button. Without this dummy
 button, the first button in the form would be a widget's delete button.
@@ -15,6 +15,8 @@ the admin center.
 {% compress css %}
 <link type="text/css" rel="stylesheet" href="{% static 'widgy/css/font-awesome.css' %}">
 <link type="text/x-scss" rel="stylesheet" href="{% static 'widgy/css/widgy.scss' %}">
+<link rel="stylesheet" href="{% static 'widgy/fancybox/jquery.fancybox-1.3.4.css' %}">
+<link rel="stylesheet" href="{% static 'widgy/css/django.fusionbox.scss' %}" type="text/x-scss">
 {% for scss_file in site.admin_scss_files %}
 <link type="text/x-scss" href="{% static scss_file %}" rel="stylesheet">
 {% endfor %}
@@ -24,8 +26,20 @@ the admin center.
 {% endif %}
 <script data-main="/static/widgy/js/main" src="/static/widgy/js/require/require.js"></script>
 {% block widgy_container %}
+<ul class="widgy-tools">
+  {% block widgy_tools %}
+  {% get_action_links owner node as links %}
+  {% for link in links %}
+    <li><a class="{{ link.type }}" target="_blank" href="{{ link.url }}">{{ link.text }}</a></li>
+  {% endfor %}
+  {% endblock %}
+</ul>
 <div id="{{ html_id }}" class="widgy"></div>
 {% endblock %}
+{% compress js %}
+<script src="{% static 'widgy/fancybox/jquery.fancybox-1.3.4.js' %}"></script>
+<script src="{% static 'widgy/js/widgy.admin.js' %}"></script>
+{% endcompress %}
 <script>
   require([ 'widgy' ], function(Widgy) {
     window.widgy = new Widgy('#' + {{ html_id|json }}, {{ node_dict|json }}, {{ api_url|json }});

--- a/widgy/templatetags/widgy_tags.py
+++ b/widgy/templatetags/widgy_tags.py
@@ -90,3 +90,13 @@ def has_add_permission(context, site, obj):
 @register.assignment_tag(takes_context=True)
 def has_delete_permission(context, site, obj):
     return site.has_delete_permission(context['request'], obj)
+
+
+@register.assignment_tag
+def get_action_links(owner, root_node):
+    try:
+        get_action_links = owner.get_action_links
+    except AttributeError:
+        return []
+    else:
+        return get_action_links(root_node)

--- a/widgy/utils.py
+++ b/widgy/utils.py
@@ -2,9 +2,10 @@
 Some utility functions used throughout the project.
 """
 from itertools import ifilterfalse
+from contextlib import contextmanager
 
 import bs4
-from contextlib import contextmanager
+
 from django.utils.html import conditional_escape
 from django.utils.safestring import mark_safe
 from django.template import Context
@@ -46,10 +47,8 @@ except ImportError:
 
 def extract_id(url):
     """
-    :Returns: the -2 index of a URL path.
-
     >>> extract_id('/bacon/eggs/')
-    'bacon'
+    'eggs'
     """
     return url and url.split('/')[-2]
 


### PR DESCRIPTION
Models with WidgyFields should define a get_action_links method. It takes a root_node and returns a list of links. This is used for preview links.
- Removes the dependency in core on widgy_mezzanine for preview links
- Removes the VersionCommitAdmin.get_commit_name and get_commit_preview_url methods.
- Removes an attempt at making forms.WidgyField work for non-model forms. We'll revisit this when it comes up.
- Adds preview and diff links for every owner of a VersionTracker.
