### PR TITLE
Changing the preview_template for something with a shelf results in two shelfs

### DIFF
--- a/widgy/static/widgy/js/nodes/nodes.js
+++ b/widgy/static/widgy/js/nodes/nodes.js
@@ -72,9 +72,6 @@ define([ 'exports', 'jquery', 'underscore', 'widgy.backbone', 'lib/q', 'shelves/
       this
         .listenTo(this.node, 'remove', this.close);
 
-      this
-        .listenTo(this.content, 'change:preview_template', this.rerender);
-
       this.list = new Backbone.ViewList();
     },
 


### PR DESCRIPTION
![image](https://f.cloud.github.com/assets/21784/689454/6853a720-dab3-11e2-82db-34378f04cf2b.png)

The `change:preview_template` must be being fired before the code that removes the old shelf.  Rerendering fixes the problem.
