### PR TITLE
Add 'owner' links on the history page and the form submissions page

### DIFF
--- a/widgy/contrib/form_builder/admin.py
+++ b/widgy/contrib/form_builder/admin.py
@@ -1,5 +1,3 @@
-import csv
-
 from django.contrib import admin
 from django.contrib.admin.util import unquote
 from django.http import HttpResponse
@@ -7,9 +5,11 @@ from django.shortcuts import render
 from django.utils.translation import ugettext_lazy as _
 from django.conf.urls import patterns, url
 from django.template.defaultfilters import slugify
+from django.db.models import Q
 
 from widgy.utils import force_text
 
+from widgy.contrib.review_queue.models import ReviewedVersionTracker
 from .models import Form
 
 
@@ -37,6 +37,14 @@ class FormAdmin(admin.ModelAdmin):
 
         headers = obj.submissions.get_formfield_labels()
         rows = obj.submissions.as_ordered_dictionaries(headers.keys())
+
+        owners = []
+        root_node = obj.node.get_root()
+        # XXX: we need a site here to call get_version_tracker_model
+        for vt in ReviewedVersionTracker.objects.filter(
+            Q(commits__root_node=root_node) | Q(working_copy=root_node)).distinct():
+            owners.extend(vt.owners)
+
         return render(request, 'admin/form_builder/form/change_form.html', {
             'title': _('View %s submissions') % force_text(opts.verbose_name),
             'object_id': object_id,
@@ -46,6 +54,7 @@ class FormAdmin(admin.ModelAdmin):
             'headers': headers,
             'rows': rows,
             'csv_file_name': self.csv_file_name(obj),
+            'owners': owners,
         })
 
     def csv_file_name(self, obj):

--- a/widgy/contrib/form_builder/templates/admin/form_builder/form/change_form.html
+++ b/widgy/contrib/form_builder/templates/admin/form_builder/form/change_form.html
@@ -1,7 +1,7 @@
 {% extends "admin/change_form.html" %}
 {% load url from future %}
 
-{% load i18n %}
+{% load i18n widgy_tags %}
 
 {% block content %}
 <div id="content-main">
@@ -10,6 +10,11 @@
     <li><a href="{% url 'admin:form_builder_form_download' object_id %}" download="{{ csv_file_name }}">{% trans 'Download as CSV' %}</a></li>
   </ul>
   {% endblock %}
+  {% for owner in owners %}
+    {% if owner|admin_edit_url %}
+      <a href="{{ owner|admin_edit_url }}">&laquo; {{ owner }}</a>
+    {% endif %}
+  {% endfor %}
 
   <table>
     <thead>

--- a/widgy/contrib/widgy_mezzanine/templates/widgy/history.html
+++ b/widgy/contrib/widgy_mezzanine/templates/widgy/history.html
@@ -19,6 +19,11 @@
 {% block content %}
 <section class="main">
   <h1>{% trans "Page History" %}</h1>
+  {% for owner in object.owners %}
+    {% if owner|admin_edit_url %}
+      <a href="{{ owner|admin_edit_url }}">&laquo; {{ owner }}</a>
+    {% endif %}
+  {% endfor %}
 <ol class="history">
     {% for commit in commits %}
     <li>

--- a/widgy/templatetags/widgy_tags.py
+++ b/widgy/templatetags/widgy_tags.py
@@ -1,4 +1,5 @@
 from django import template
+from django.core import urlresolvers
 from django.conf import settings
 from django.utils.safestring import mark_safe
 
@@ -100,3 +101,14 @@ def get_action_links(owner, root_node):
         return []
     else:
         return get_action_links(root_node)
+
+@register.filter
+def admin_edit_url(obj):
+    try:
+        name = 'admin:%s_%s_change' % (
+            obj._meta.app_label,
+            obj._meta.module_name,
+        )
+        return urlresolvers.reverse(name, args=[obj.pk])
+    except urlresolvers.NoReverseMatch:
+        return ''


### PR DESCRIPTION
Add a link to the admin change page of each owner. This can not be merged as-is --- the form admin hardcodes a reference to ReviewedVersionTracker. It needs access to a site so it can call get_version_tracker_model.
