### PR TITLE
added sorl.thumbnail to demo's INSTALLED_APPS

### DIFF
--- a/demo/settings.py
+++ b/demo/settings.py
@@ -293,6 +293,7 @@ INSTALLED_APPS = (
     'filer',
     'easy_thumbnails',
     'widgy.contrib.urlconf_include',
+    'sorl.thumbnail',
 
     # local project
     'demo.demo_widgets'


### PR DESCRIPTION
I was exploring this project, and I found that images were not displaying. I added sorl.thumbnail to INSTALLED_APPS and ran syncdb to clear the error. 
