### PR TITLE
Migrations Failing on sqlite

### DIFF
--- a/widgy/contrib/form_builder/migrations/0013_auto__chg_field_emailsuccesshandler_content__chg_field_emailuserhandle.py
+++ b/widgy/contrib/form_builder/migrations/0013_auto__chg_field_emailsuccesshandler_content__chg_field_emailuserhandle.py
@@ -27,9 +27,9 @@ def convert_model(ModelClass, converter):
 class Migration(SchemaMigration):
 
     def forwards(self, orm):
-
-        convert_model(orm.EmailSuccessHandler, process_markdown)
-        convert_model(orm.EmailUserHandler, process_markdown)
+        if not db.dry_run:
+            convert_model(orm.EmailSuccessHandler, process_markdown)
+            convert_model(orm.EmailUserHandler, process_markdown)
 
         # Changing field 'EmailSuccessHandler.content'
         db.alter_column(u'form_builder_emailsuccesshandler', 'content', self.gf('django.db.models.fields.TextField')())
@@ -38,9 +38,9 @@ class Migration(SchemaMigration):
         db.alter_column(u'form_builder_emailuserhandler', 'content', self.gf('django.db.models.fields.TextField')())
 
     def backwards(self, orm):
-
-        convert_model(orm.EmailSuccessHandler, html2text.html2text)
-        convert_model(orm.EmailUserHandler, html2text.html2text)
+        if not db.dry_run:
+            convert_model(orm.EmailSuccessHandler, html2text.html2text)
+            convert_model(orm.EmailUserHandler, html2text.html2text)
 
         # Changing field 'EmailSuccessHandler.content'
         db.alter_column(u'form_builder_emailsuccesshandler', 'content', self.gf('widgy.contrib.page_builder.db.fields.MarkdownField')())


### PR DESCRIPTION
```
Running migrations for conf:
 - Migrating forwards to 0004_ssl_account_settings_rename.
 > conf:0001_initial
 > conf:0002_auto__add_field_setting_site
 > conf:0003_update_site_setting
 - Migration 'conf:0003_update_site_setting' is marked for no-dry-run.
 > conf:0004_ssl_account_settings_rename
 - Migration 'conf:0004_ssl_account_settings_rename' is marked for no-dry-run.
 - Loading initial data for conf.
Installed 0 object(s) from 0 fixture(s)
Running migrations for core:
 - Migrating forwards to 0005_auto__chg_field_sitepermission_user__del_unique_sitepermission_user.
 > core:0001_initial
 > pages:0001_initial
 > pages:0002_auto__del_field_page__keywords__add_field_page_keywords_string__chg_fi
 > core:0002_auto__del_keyword
 > core:0003_auto__add_sitepermission
 > core:0004_set_site_permissions
 - Migration 'core:0004_set_site_permissions' is marked for no-dry-run.
 > core:0005_auto__chg_field_sitepermission_user__del_unique_sitepermission_user
 - Loading initial data for core.
Installed 0 object(s) from 0 fixture(s)
Running migrations for generic:
 - Migrating forwards to 0014_auto__add_field_rating_user.
 > generic:0001_initial
 > generic:0002_auto__add_keyword__add_assignedkeyword
 > generic:0003_auto__add_rating
 > generic:0004_auto__chg_field_rating_object_pk__chg_field_assignedkeyword_object_pk
 > generic:0005_keyword_site
 > generic:0006_move_keywords
 - Migration 'generic:0006_move_keywords' is marked for no-dry-run.
 > generic:0007_auto__add_field_assignedkeyword__order
 > generic:0008_set_keyword_order
 - Migration 'generic:0008_set_keyword_order' is marked for no-dry-run.
 > generic:0009_auto__chg_field_keyword_title__chg_field_keyword_slug
 > generic:0009_auto__del_field_threadedcomment_email_hash
 > generic:0010_auto__chg_field_keyword_slug__chg_field_keyword_title
 > generic:0011_auto__add_field_threadedcomment_rating_count__add_field_threadedcommen
 > generic:0012_auto__add_field_rating_rating_date
 > generic:0013_auto__add_field_threadedcomment_rating_sum
 > generic:0014_auto__add_field_rating_user
 - Loading initial data for generic.
Installed 0 object(s) from 0 fixture(s)
Running migrations for pages:
 - Migrating forwards to 0013_auto__add_field_page_in_sitemap.
 > pages:0003_auto__add_field_page_site
 > pages:0004_auto__del_contentpage__add_richtextpage
 > pages:0005_rename_contentpage
 - Migration 'pages:0005_rename_contentpage' is marked for no-dry-run.
 > pages:0006_auto__add_field_page_gen_description
 > pages:0007_auto__chg_field_page_slug__chg_field_page_title
 > pages:0008_auto__add_link
 > pages:0009_add_field_page_in_menus
 > pages:0010_set_menus
 - Migration 'pages:0010_set_menus' is marked for no-dry-run.
 > pages:0011_delete_nav_flags
 > pages:0012_add_field_page__meta_title
 > pages:0013_auto__add_field_page_in_sitemap
 - Loading initial data for pages.
Installed 0 object(s) from 0 fixture(s)
Running migrations for widgy:
 - Migrating forwards to 0010_auto__add_unique_versiontracker_head__add_unique_versiontracker_workin.
 > widgy:0001_initial
 > widgy:0002_auto__del_imagecontent__del_twocolumnlayout__del_bucket__del_textconte
 > widgy:0003_auto__add_versiontracker__add_versioncommit
 > widgy:0004_auto__add_field_node_frozen
 > widgy:0005_auto__chg_field_versiontracker_head__chg_field_versiontracker_working_
 > widgy:0006_auto__add_field_versioncommit_message
 > widgy:0007_auto__add_field_versioncommit_publish_at
/Users/aaronmerriam/.virtualenvs/jilly/lib/python2.7/site-packages/django/db/models/fields/__init__.py:827: RuntimeWarning: DateTimeField received a naive datetime (1970-01-01 00:00:00) while time zone support is active.
  RuntimeWarning)

 > widgy:0008_auto__chg_field_versioncommit_created_at__chg_field_versioncommit_publ
 > widgy:0009_auto__add_unique_node_content_id_content_type
 > widgy:0010_auto__add_unique_versiontracker_head__add_unique_versiontracker_workin
 - Loading initial data for widgy.
Installed 0 object(s) from 0 fixture(s)
Running migrations for page_builder:
 - Migrating forwards to 0013_auto__add_unsafehtml.
 > page_builder:0001_initial
 > filer:0001_initial
 > page_builder:0002_auto__add_image
 > page_builder:0002_auto__add_tablerow__add_table__add_tabledata
 > page_builder:0002_auto__add_video
 > page_builder:0003_auto__add_tableheaderdata__add_tableheader__add_tablebody__add_field_t
 > page_builder:0003_auto__add_widgyimagefile__chg_field_image_image
 > page_builder:0004_auto__del_field_tabledata_column
 > page_builder:0004_auto__del_widgyimagefile__chg_field_image_image
 > page_builder:0005_merge
 > page_builder:0006_auto__add_figure
 > page_builder:0007_merge
 > page_builder:0008_auto__del_field_video_title__del_field_video_caption
 > page_builder:0009_auto__add_button
 > page_builder:0010_auto__add_html
 > page_builder:0011_auto__chg_field_html_content
 > page_builder:0012_auto__add_googlemap
 > page_builder:0013_auto__add_unsafehtml
 - Loading initial data for page_builder.
Installed 0 object(s) from 0 fixture(s)
Running migrations for widgy_mezzanine:
 - Migrating forwards to 0002_auto__chg_field_widgypage_root_node.
 > widgy_mezzanine:0001_initial
 > widgy_mezzanine:0002_auto__chg_field_widgypage_root_node
 - Loading initial data for widgy_mezzanine.
Installed 0 object(s) from 0 fixture(s)
Running migrations for urlconf_include:
 - Migrating forwards to 0001_initial.
 > urlconf_include:0001_initial
 - Loading initial data for urlconf_include.
Installed 0 object(s) from 0 fixture(s)
Running migrations for filer:
 - Migrating forwards to 0014_auto__add_field_image_related_url__chg_field_file_name.
 > filer:0002_rename_file_field
 > filer:0003_add_description_field
 > filer:0004_auto__del_field_file__file__add_field_file_file__add_field_file_is_pub
 > filer:0005_auto__add_field_file_sha1__chg_field_file_file
 > filer:0006_polymorphic__add_field_file_polymorphic_ctype
 > filer:0007_polymorphic__content_type_data
 - Migration 'filer:0007_polymorphic__content_type_data' is marked for no-dry-run.
 > filer:0008_polymorphic__del_field_file__file_type_plugin_name
 > filer:0009_auto__add_field_folderpermission_can_edit_new__add_field_folderpermiss
 > filer:0010_folderpermissions
 - Migration 'filer:0010_folderpermissions' is marked for no-dry-run.
 > filer:0011_auto__del_field_folderpermission_can_add_children__del_field_folderper
 > filer:0012_renaming_folderpermissions
 > filer:0013_remove_null_file_name
 - Migration 'filer:0013_remove_null_file_name' is marked for no-dry-run.
 > filer:0014_auto__add_field_image_related_url__chg_field_file_name
 - Loading initial data for filer.
Installed 0 object(s) from 0 fixture(s)
Running migrations for easy_thumbnails:
 - Migrating forwards to 0015_auto__del_unique_thumbnail_name_storage_hash__add_unique_thumbnail_sou.
 > easy_thumbnails:0001_initial
 > easy_thumbnails:0002_filename_indexes
 > easy_thumbnails:0003_auto__add_storagenew
 > easy_thumbnails:0004_auto__add_field_source_storage_new__add_field_thumbnail_storage_new
 > easy_thumbnails:0005_storage_fks_null
 > easy_thumbnails:0006_copy_storage
 - Migration 'easy_thumbnails:0006_copy_storage' is marked for no-dry-run.
 > easy_thumbnails:0007_storagenew_fks_not_null
 > easy_thumbnails:0008_auto__del_field_source_storage__del_field_thumbnail_storage
 > easy_thumbnails:0009_auto__del_storage
 > easy_thumbnails:0010_rename_storage
 > easy_thumbnails:0011_auto__add_field_source_storage_hash__add_field_thumbnail_storage_hash
 > easy_thumbnails:0012_build_storage_hashes
 - Migration 'easy_thumbnails:0012_build_storage_hashes' is marked for no-dry-run.
 > easy_thumbnails:0013_auto__del_storage__del_field_source_storage__del_field_thumbnail_stora
 > easy_thumbnails:0014_auto__add_unique_source_name_storage_hash__add_unique_thumbnail_name_s
 > easy_thumbnails:0015_auto__del_unique_thumbnail_name_storage_hash__add_unique_thumbnail_sou
 - Loading initial data for easy_thumbnails.
Installed 0 object(s) from 0 fixture(s)
Running migrations for core:
- Nothing to migrate.
 - Loading initial data for core.
Installed 0 object(s) from 0 fixture(s)
Running migrations for django_extensions:
 - Migrating forwards to 0001_empty.
 > django_extensions:0001_empty
 - Loading initial data for django_extensions.
Installed 0 object(s) from 0 fixture(s)
Running migrations for form_builder:
 - Migrating forwards to 0014_auto__add_field_emailsuccesshandler_include_form_data__add_field_email.
 > form_builder:0001_initial
 > form_builder:0002_auto__add_emailsuccesshandler
 > form_builder:0003_auto__add_formvalue__add_savedatahandler__add_formsubmission__add_fiel
 > form_builder:0004_auto__add_field_textarea_required__add_field_forminput_required
 > form_builder:0005_auto__add_uncaptcha
 > form_builder:0006_auto__add_emailuserhandler
 > form_builder:0007_auto__add_multiplechoicefield__add_choicefield
 > form_builder:0008_auto__add_field_emailsuccesshandler_subject
 > form_builder:0009_auto__add_successmessagebucket__add_formmeta__add_successhandlers__add
 > form_builder:0010_auto__add_field_emailuserhandler_to_ident__chg_field_formsubmission_cr
 > form_builder:0011_populate_to_ident
 - Migration 'form_builder:0011_populate_to_ident' is marked for no-dry-run.
 > form_builder:0012_auto__del_field_emailuserhandler_to
 > form_builder:0013_auto__chg_field_emailsuccesshandler_content__chg_field_emailuserhandle
FailedDryRun:  ! Error found during dry run of '0013_auto__chg_field_emailsuccesshandler_content__chg_field_emailuserhandle'! Aborting.
Traceback (most recent call last):
  File "/Users/aaronmerriam/.virtualenvs/jilly/lib/python2.7/site-packages/south/migration/migrators.py", line 173, in _run_migration
    migration_function()
  File "/Users/aaronmerriam/.virtualenvs/jilly/lib/python2.7/site-packages/south/migration/migrators.py", line 62, in <lambda>
    return (lambda: direction(orm))
  File "/Users/aaronmerriam/.virtualenvs/jilly/src/django-widgy-dev/widgy/contrib/form_builder/migrations/0013_auto__chg_field_emailsuccesshandler_content__chg_field_emailuserhandle.py", line 31, in forwards
    convert_model(orm.EmailSuccessHandler, process_markdown)
  File "/Users/aaronmerriam/.virtualenvs/jilly/src/django-widgy-dev/widgy/contrib/form_builder/migrations/0013_auto__chg_field_emailsuccesshandler_content__chg_field_emailuserhandle.py", line 22, in convert_model
    for obj in ModelClass.objects.all():
  File "/Users/aaronmerriam/.virtualenvs/jilly/lib/python2.7/site-packages/south/orm.py", line 398, in __getattr__
    raise AttributeError("You are in a dry run, and cannot access the ORM.\nWrap ORM sections in 'if not db.dry_run:', or if the whole migration is only a data migration, set no_dry_run = True on the Migration class.")
AttributeError: You are in a dry run, and cannot access the ORM.
Wrap ORM sections in 'if not db.dry_run:', or if the whole migration is only a data migration, set no_dry_run = True on the Migration class.
```
