### PR TITLE
Fixed issue with deleting tab while EditorView is active

### DIFF
--- a/widgy/static/widgy/js/components/tabbed/component.js
+++ b/widgy/static/widgy/js/components/tabbed/component.js
@@ -17,6 +17,7 @@ define([ 'underscore', 'widgy.backbone', 'components/widget/component' ], functi
 
     showTabAfterTabDestroy: function(model, collection, options) {
       if(this.list.size() < 1) {
+        this.renderNode();
         return;
       }
 


### PR DESCRIPTION
Add a Tabs widget - Add Section - Edit Widget - Delete Section: The EditorView is still active. This rerenders it to make sure this does not happen. It only happens when one tab is open. 
