### PR TITLE
Ensure deletion of child elements when deleting a Node.

### DIFF
--- a/widgy/static/widgy/js/nodes/nodes.js
+++ b/widgy/static/widgy/js/nodes/nodes.js
@@ -386,6 +386,11 @@ define([ 'exports', 'jquery', 'underscore', 'widgy.backbone', 'lib/q', 'shelves/
         this.shelf.close();
     },
 
+    close: function() {
+      this.cleanUp();
+      DraggableView.prototype.close.apply(this, arguments);
+    },
+
     renderNode: function() {
       return DraggableView.prototype.renderPromise.apply(this, arguments).then(function(view) {
         view.$children = view.$(' > .widget > .node_children');


### PR DESCRIPTION
This fixes issue #136 regarding the left behind edit/preview element
when deleting the last remaining Section.  Thanks to @zmetcalf for
discovering this bug.
