### PR TITLE
Added StrDisplayNameMixin to many widgets.

### DIFF
--- a/widgy/models/mixins.py
+++ b/widgy/models/mixins.py
@@ -2,6 +2,8 @@ from __future__ import unicode_literals
 
 from operator import attrgetter
 
+import six
+
 
 class DefaultChildrenMixin(object):
     """
@@ -115,3 +117,4 @@ def DisplayNameMixin(fn):
 
 
 TitleDisplayNameMixin = DisplayNameMixin(attrgetter('title'))
+StrDisplayNameMixin = DisplayNameMixin(six.text_type)


### PR DESCRIPTION
`StrDisplayNameMixin` uses the `__unicode__` or `__str__` methods of the
widgets to create the `display_name`.  This is better than using a lambda
in the `DisplayNameMixin` because it forces the programmer to also write a
`__str__` method for the model.

I also took the liberty of placing the Meta classes where I felt they should be.
