### PR TITLE
Fix multi-table inheritance with LinkFields

### DIFF
--- a/tests/modeltests/core_tests/models.py
+++ b/tests/modeltests/core_tests/models.py
@@ -211,6 +211,10 @@ class ThingWithLink(models.Model):
     link = links.LinkField('linkable_content_type', 'linkable_object_id')
 
 
+class ChildThingWithLink(ThingWithLink):
+    pass
+
+
 class MyInvisibleBucket(InvisibleMixin, Content):
     """
     This is for testing template hierarchy

--- a/tests/modeltests/core_tests/tests/links.py
+++ b/tests/modeltests/core_tests/tests/links.py
@@ -8,8 +8,17 @@ from widgy.models.links import (
 
 from modeltests.core_tests.models import (
     LinkableThing, ThingWithLink, AnotherLinkableThing, LinkableThing3,
-    Bucket, VersionPageThrough
+    Bucket, VersionPageThrough, ChildThingWithLink
 )
+
+
+class TestLinkField(TestCase):
+    def test_inheritance(self):
+        # the only field local to ChildThingWithLink is its pk. The link
+        # field is inherited, so it shouldn't be in local_fields.
+        self.assertFalse(any(
+            i.name == 'linkable_content_type' for i in ChildThingWithLink._meta.local_fields
+        ))
 
 
 class TestLinkRelations(TestCase):

--- a/widgy/models/links.py
+++ b/widgy/models/links.py
@@ -72,12 +72,14 @@ class LinkField(WidgyGenericForeignKey):
         if self.fk_field is None:
             self.fk_field = '%s_object_id' % name
 
-        if self.ct_field not in [i.name for i in cls._meta.local_fields]:
+        # do not do anything that loads the app cache here, like
+        # _meta.get_all_field_names, or you'll cause a circular import.
+        if self.ct_field not in [i.name for i, _ in cls._meta.get_fields_with_model()]:
             ct_field = models.ForeignKey(ContentType, related_name='+',
                                          null=self.null, editable=False)
             cls.add_to_class(self.ct_field, ct_field)
 
-        if self.fk_field not in [i.name for i in cls._meta.local_fields]:
+        if self.fk_field not in [i.name for i, _ in cls._meta.get_fields_with_model()]:
             fk_field = models.PositiveIntegerField(null=self.null,
                                                    editable=False)
             cls.add_to_class(self.fk_field, fk_field)


### PR DESCRIPTION
The fields LinkFields adds were getting added twice when inheriting from a model with a LinkField. LinkField tries to prevent this by check if the fields are already there, but it only checked local_fields. It needs to check all model fields, including inherited fields.

164ea5f00b3db switched from using get_all_field_names to local_fields, because get_all_field_names loads the appcache which can cause a circular import. This commit uses get_fields_with_model, which does not load the appcache, so it should be ok.
