### PR TITLE
use scrollBy instead of scrollTop+=

### DIFF
--- a/widgy/static/widgy/js/nodes/base.js
+++ b/widgy/static/widgy/js/nodes/base.js
@@ -3,7 +3,7 @@ define(['jquery', 'underscore', 'widgy.backbone'], function(
       ) {
 
   var bump = _.throttle(function(amount) {
-    document.body.scrollTop += amount;
+    window.scrollBy(0, amount);
   }, 100);
 
   var BACKTICK = 96;


### PR DESCRIPTION
Setting scrollTop doesn't do anything in Firefox or IE, so use window.scrollBy which is supported everywhere.
