### PR TITLE
Drop target collision detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ js_tests/node_modules: js_tests/package.json
 test-js: js_tests/node_modules
 	./js_tests/node_modules/mocha/bin/mocha \
 		-s 5 \
-		--reporter nyan \
+		--reporter spec \
 		$(JS_FILES)
 
 widgy/locale/en/LC_MESSAGES/django.po: $(shell find . -type f -iregex '.*\.\(html\|py\|md\)$$' | grep -v .tox)

--- a/js_tests/tests/test_geometry.js
+++ b/js_tests/tests/test_geometry.js
@@ -1,0 +1,70 @@
+var test = require('./setup').test,
+   requirejs = require('requirejs'),
+   assert = require('chai').assert;
+
+var geometry = requirejs('geometry');
+
+
+describe('calculateDistance', function() {
+ var box = {
+   top: 1,
+   left: 1,
+   right: 3,
+   bottom: 3
+ };
+ it('knows when we are inside', function() {
+   assert.equal(geometry.calculateDistance(box, 1, 1), 0);
+   assert.equal(geometry.calculateDistance(box, 2, 2), 0);
+   assert.equal(geometry.calculateDistance(box, 3, 3), 0);
+   assert.equal(geometry.calculateDistance(box, 3, 2), 0);
+ });
+
+ it('works outside', function() {
+   assert.equal(geometry.calculateDistance(box, 0, 0), 2);
+   assert.equal(geometry.calculateDistance(box, 4, 4), 2);
+   assert.equal(geometry.calculateDistance(box, 5, 2), 4);
+   assert.equal(geometry.calculateDistance(box, 0, 2), 1);
+   assert.equal(geometry.calculateDistance(box, 4, 2), 1);
+   assert.equal(geometry.calculateDistance(box, 2, 0), 1);
+   assert.equal(geometry.calculateDistance(box, 2, 4), 1);
+ });
+});
+
+describe('rectanglesOverlap', function() {
+  it('overlap', function() {
+    assert.ok(geometry.rectanglesOverlap({top: 1, left: 1, right: 2, bottom: 2},
+                                         {top: 1, left: 1, right: 2, bottom: 2}));
+  });
+  it('left>right', function() {
+    assert.ok(!geometry.rectanglesOverlap({top: 2, left: 2, right: 3, bottom: 3},
+                                          {top: 2, left: 1, right: 1, bottom: 3}));
+  });
+  it('left=right', function() {
+    assert.ok(geometry.rectanglesOverlap({top: 2, left: 2, right: 3, bottom: 3},
+                                         {top: 2, left: 1, right: 2, bottom: 3}));
+  });
+  it('right<left', function() {
+    assert.ok(!geometry.rectanglesOverlap({top: 2, left: 2, right: 3, bottom: 3},
+                                          {top: 2, left: 4, right: 5, bottom: 3}));
+  });
+  it('right=left', function() {
+    assert.ok(geometry.rectanglesOverlap({top: 2, left: 2, right: 3, bottom: 3},
+                                         {top: 2, left: 3, right: 5, bottom: 3}));
+  });
+  it('top>bottom', function() {
+    assert.ok(!geometry.rectanglesOverlap({top: 2, left: 1, right: 2, bottom: 3},
+                                          {top: 0, left: 1, right: 2, bottom: 1}));
+  });
+  it('top=bottom', function() {
+    assert.ok(geometry.rectanglesOverlap({top: 2, left: 1, right: 2, bottom: 3},
+                                         {top: 0, left: 1, right: 2, bottom: 2}));
+  });
+  it('bottom<top', function() {
+    assert.ok(!geometry.rectanglesOverlap({top: 1, left: 1, right: 2, bottom: 2},
+                                          {top: 3, left: 1, right: 2, bottom: 4}));
+  });
+  it('bottom=top', function() {
+    assert.ok(geometry.rectanglesOverlap({top: 1, left: 1, right: 2, bottom: 2},
+                                         {top: 2, left: 1, right: 2, bottom: 4}));
+  });
+});

--- a/widgy/static/widgy/js/geometry.js
+++ b/widgy/static/widgy/js/geometry.js
@@ -1,0 +1,25 @@
+define([], function() {
+  return {
+    /**
+     * Returns the square of the distance between the point (px, py) and any
+     * point in the rectangle bb (zero if the point is inside)
+     */
+    calculateDistance: function (bb, px, py) {
+      var dx, dy;
+      dy = Math.max(Math.max(bb.top - py, py - bb.bottom), 0);
+      dx = Math.max(Math.max(bb.left - px, px - bb.right), 0);
+      return dx * dx + dy * dy;
+    },
+
+    /**
+     * Do the rectangles described by bb and obb overlap? The rectangles should
+     * be in the format returned by Element.getBoundingClientRect.
+     */
+    rectanglesOverlap: function(bb, obb) {
+      return (
+        bb.left <= obb.right && bb.right >= obb.left &&
+        bb.top <= obb.bottom && bb.bottom >= obb.top
+      );
+    }
+  };
+});

--- a/widgy/static/widgy/js/nodes/nodes.js
+++ b/widgy/static/widgy/js/nodes/nodes.js
@@ -1,9 +1,9 @@
-define([ 'exports', 'jquery', 'underscore', 'widgy.backbone', 'lib/q', 'shelves/shelves', 'modal/modal',
+define([ 'exports', 'jquery', 'underscore', 'widgy.backbone', 'lib/q', 'shelves/shelves', 'modal/modal', 'geometry',
     'text!./drop_target.html',
     'text!./popped_out.html',
     'nodes/base',
     'nodes/models'
-    ], function(exports, $, _, Backbone, Q, shelves, modal,
+    ], function(exports, $, _, Backbone, Q, shelves, modal, geometry,
       drop_target_view_template,
       popped_out_template,
       DraggableView,
@@ -56,7 +56,8 @@ define([ 'exports', 'jquery', 'underscore', 'widgy.backbone', 'lib/q', 'shelves/
         'popOut',
         'popIn',
         'prepareChild',
-        'closeSubwindow'
+        'closeSubwindow',
+        'refreshDropTargetVisibility'
         );
 
       this.node = this.model;
@@ -290,7 +291,26 @@ define([ 'exports', 'jquery', 'underscore', 'widgy.backbone', 'lib/q', 'shelves/
         this.list.each(function(node_view) {
           var drop_target = that.createDropTarget(view).$el.insertAfter(node_view.el);
         }, this);
+        this.refreshDropTargetVisibility();
+
+        $(window).on('scroll.' + this.cid, function() {
+          that.refreshDropTargetVisibility();
+        });
       }
+    },
+
+    refreshDropTargetVisibility: function() {
+      var that = this;
+      var visible = 0;
+      this.drop_targets_list.each(function(drop_target) {
+        that.app.visible_drop_targets.remove(drop_target);
+        if ( drop_target.isVisible() ) {
+          that.app.visible_drop_targets.push(drop_target);
+          visible++;
+        }
+      });
+
+      debug('refreshDropTargetVisibility', visible + ' of ' + this.drop_targets_list.size() + ' visible');
     },
 
     createDropTarget: function(view) {
@@ -316,6 +336,8 @@ define([ 'exports', 'jquery', 'underscore', 'widgy.backbone', 'lib/q', 'shelves/
     },
 
     clearDropTargets: function() {
+      $(window).off('scroll.' + this.cid);
+
       this.drop_targets_list.closeAll();
 
       this.list.each(function(node_view) {
@@ -525,62 +547,31 @@ define([ 'exports', 'jquery', 'underscore', 'widgy.backbone', 'lib/q', 'shelves/
   var DropTargetView = Backbone.View.extend({
     tagName: 'li',
     className: 'node_drop_target',
+    active: false,
     template: drop_target_view_template,
 
-    triggers: {
-      'mouseup': 'dropped'
-    },
-
-    events: Backbone.extendEvents(Backbone.View, {
-      'mouseenter': 'activate',
-      'mouseleave': 'deactivate'
-    }),
-
-    render: function() {
-      Backbone.View.prototype.render.apply(this, arguments);
-
-      // In a perfect world, the CSS pointer-events property would be supported
-      // by all browsers and every version of each browser and we would set
-      // pointer-events to none for .node.being_dragged.  But even since we
-      // can't use that, we are going to use this method to capture all of the
-      // events.
-      //
-      // Above the drop targets, we put an invisible div that has a z-index
-      // high enough to be above the dragged_node.  This allows us to catch the
-      // pointer events (mouseup, mouseenter, mouseleave) that we need drop
-      // targets to receive.
-      //
-      // Normally I don't like putting CSS in the JavaScript, but this CSS
-      // creates functionality and not prettiness, so I have to.
-      this.$el.css({
-        'position': 'relative'
-      });
-
-      var $pointerEventsCatcher = $('<div class="pointer_event_catcher">')
-        .css({
-          'z-index': 51,
-          'opacity': 0,
-          'width': '100%',
-          'height': '100%',
-          'padding': '20px 40px',
-          'position': 'absolute',
-          'top': '-20px',
-          'left': '-40px'
-        });
-      this.$el.prepend($pointerEventsCatcher);
-
-      return this;
-    },
-
     activate: function(event) {
+      this.active = true;
       this.$el.addClass('active');
       return this;
     },
 
     deactivate: function(event) {
+      this.active = false;
       this.$el.removeClass('active')
               .css('height', '');
       return this;
+    },
+
+    isVisible: function() {
+      var bounds = this.el.getBoundingClientRect();
+      var windowBounds = {
+        top: 0,
+        left: 0,
+        bottom: window.innerHeight || document.documentElement.clientHeight,
+        right: window.innerWidth || document.documentElement.clientWidth
+      };
+      return geometry.rectanglesOverlap(bounds, windowBounds);
     }
   });
 

--- a/widgy/static/widgy/js/widgy.backbone.js
+++ b/widgy/static/widgy/js/widgy.backbone.js
@@ -1,4 +1,4 @@
-define([ 'jquery', 'underscore', 'backbone', 'lib/mustache', 'lib/q' ], function($, _, Backbone, Mustache, Q) {
+define([ 'jquery', 'underscore', 'backbone', 'lib/mustache', 'lib/q', 'geometry' ], function($, _, Backbone, Mustache, Q, geometry) {
 
   Mustache.tags = ['<%', '%>'];
 
@@ -212,6 +212,14 @@ define([ 'jquery', 'underscore', 'backbone', 'lib/mustache', 'lib/q' ], function
     findByModel: function(model) {
       return this.find(function(view) {
         return model === view.model;
+      });
+    },
+
+    filterByOverlappingEl: function(el) {
+      bb = el.getBoundingClientRect();
+      return _.filter(this.list, function(view) {
+        obb = view.el.getBoundingClientRect();
+        return geometry.rectanglesOverlap(bb, obb);
       });
     },
 

--- a/widgy/static/widgy/js/widgy.js
+++ b/widgy/static/widgy/js/widgy.js
@@ -29,6 +29,7 @@ define([ 'jquery', 'underscore', 'widgy.backbone', 'lib/csrf', 'lib/q', 'nodes/n
       // instantiate node_view_list before creating the root node
       // please!
       this.node_view_list = new Backbone.ViewList();
+      this.visible_drop_targets = new Backbone.ViewList();
 
       var root_node = this.root_node = new nodes.Node(options.root_node),
           app = this;
@@ -84,7 +85,7 @@ define([ 'jquery', 'underscore', 'widgy.backbone', 'lib/csrf', 'lib/q', 'nodes/n
         this.inflight.abort();
 
       this.inflight = $.ajax({
-        url: this.root_node.get('available_children_url'),
+        url: this.root_node.get('available_children_url')
       });
 
       return Q(this.inflight);


### PR DESCRIPTION
Instead of using the pointer_event_catcher to activate drop targets, activate the drop target closest to the mouse that overlaps the dragged element.

As an optimization, only drop targets visible in the viewport are checked for overlap. The list of visible drop targets is refreshed on scroll.

https://groups.google.com/a/fusionbox.com/forum/#!topic/widgy/HqV-eEAZ8BM
