### PR TITLE
use the master branch for the travis badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Widgy: Tree Editor for Django
 =============================
 
-.. image:: https://travis-ci.org/fusionbox/django-widgy.png
+.. image:: https://travis-ci.org/fusionbox/django-widgy.png?branch=master
    :target: http://travis-ci.org/fusionbox/django-widgy
    :alt: Build Status
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,7 +27,7 @@ developers mailing list available at `widgy@fusionbox.com
 <https://groups.google.com/a/fusionbox.com/forum/#!forum/widgy>`_
 
 
-.. image:: https://travis-ci.org/fusionbox/django-widgy.png
+.. image:: https://travis-ci.org/fusionbox/django-widgy.png?branch=master
    :target: http://travis-ci.org/fusionbox/django-widgy
    :alt: Build Status
 


### PR DESCRIPTION
failures in branches besides master shouldn't be reported
