### PR TITLE
django-widgy update to django 1.6

### DIFF
--- a/demo/demo_url/urls.py
+++ b/demo/demo_url/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, include, url
+from django.conf.urls import patterns, include, url
 from django.views.generic import RedirectView
 
 from . import views

--- a/demo/urls.py
+++ b/demo/urls.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.conf.urls.defaults import patterns, include, url
+from django.conf.urls import patterns, include, url
 from django.contrib import admin
 
 from mezzanine.core.views import direct_to_template


### PR DESCRIPTION
I am not sure where you all are with this yet.

Fixed depreciation of urls.defaults in demo: https://docs.djangoproject.com/en/dev/internals/deprecation/#id3

Fixed south migration issue: https://code.djangoproject.com/ticket/21312

Waiting on mezzanine to get to Django 1.6: 
Recent: https://groups.google.com/forum/#!topic/mezzanine-users/W4nF9nr-HtA
@gavinwahl issue: https://github.com/stephenmcd/mezzanine/issues/745
