### PR TITLE
Manually squash Widgy's first two migrations

### DIFF
--- a/widgy/migrations/0001_initial.py
+++ b/widgy/migrations/0001_initial.py
@@ -19,51 +19,9 @@ class Migration(SchemaMigration):
         ))
         db.send_create_signal('widgy', ['Node'])
 
-        # Adding model 'Bucket'
-        db.create_table('widgy_bucket', (
-            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
-            ('title', self.gf('django.db.models.fields.CharField')(max_length=255)),
-            ('draggable', self.gf('django.db.models.fields.BooleanField')(default=True)),
-            ('deletable', self.gf('django.db.models.fields.BooleanField')(default=True)),
-        ))
-        db.send_create_signal('widgy', ['Bucket'])
-
-        # Adding model 'TwoColumnLayout'
-        db.create_table('widgy_twocolumnlayout', (
-            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
-        ))
-        db.send_create_signal('widgy', ['TwoColumnLayout'])
-
-        # Adding model 'TextContent'
-        db.create_table('widgy_textcontent', (
-            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
-            ('content', self.gf('django.db.models.fields.TextField')()),
-        ))
-        db.send_create_signal('widgy', ['TextContent'])
-
-        # Adding model 'ImageContent'
-        db.create_table('widgy_imagecontent', (
-            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
-            ('image', self.gf('mezzanine.core.fields.FileField')(max_length=255)),
-        ))
-        db.send_create_signal('widgy', ['ImageContent'])
-
-
     def backwards(self, orm):
         # Deleting model 'Node'
         db.delete_table('widgy_node')
-
-        # Deleting model 'Bucket'
-        db.delete_table('widgy_bucket')
-
-        # Deleting model 'TwoColumnLayout'
-        db.delete_table('widgy_twocolumnlayout')
-
-        # Deleting model 'TextContent'
-        db.delete_table('widgy_textcontent')
-
-        # Deleting model 'ImageContent'
-        db.delete_table('widgy_imagecontent')
 
 
     models = {
@@ -74,66 +32,6 @@ class Migration(SchemaMigration):
             'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
             'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
         },
-        'generic.assignedkeyword': {
-            'Meta': {'ordering': "('_order',)", 'object_name': 'AssignedKeyword'},
-            '_order': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
-            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
-            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'keyword': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'assignments'", 'to': "orm['generic.Keyword']"}),
-            'object_pk': ('django.db.models.fields.IntegerField', [], {})
-        },
-        'generic.keyword': {
-            'Meta': {'object_name': 'Keyword'},
-            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'site': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['sites.Site']"}),
-            'slug': ('django.db.models.fields.CharField', [], {'max_length': '2000', 'null': 'True', 'blank': 'True'}),
-            'title': ('django.db.models.fields.CharField', [], {'max_length': '500'})
-        },
-        'pages.page': {
-            'Meta': {'ordering': "('titles',)", 'object_name': 'Page'},
-            '_order': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
-            'content_model': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True'}),
-            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
-            'expiry_date': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
-            'gen_description': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
-            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'in_footer': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
-            'in_navigation': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
-            'keywords': ('mezzanine.generic.fields.KeywordsField', [], {'object_id_field': "'object_pk'", 'to': "orm['generic.AssignedKeyword']", 'frozen_by_south': 'True'}),
-            'keywords_string': ('django.db.models.fields.CharField', [], {'max_length': '500', 'blank': 'True'}),
-            'login_required': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
-            'parent': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'children'", 'null': 'True', 'to': "orm['pages.Page']"}),
-            'publish_date': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
-            'short_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
-            'site': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['sites.Site']"}),
-            'slug': ('django.db.models.fields.CharField', [], {'max_length': '2000', 'null': 'True', 'blank': 'True'}),
-            'status': ('django.db.models.fields.IntegerField', [], {'default': '2'}),
-            'title': ('django.db.models.fields.CharField', [], {'max_length': '500'}),
-            'titles': ('django.db.models.fields.CharField', [], {'max_length': '1000', 'null': 'True'})
-        },
-        'sites.site': {
-            'Meta': {'ordering': "('domain',)", 'object_name': 'Site', 'db_table': "'django_site'"},
-            'domain': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
-            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
-        },
-        'widgy.bucket': {
-            'Meta': {'object_name': 'Bucket'},
-            'deletable': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
-            'draggable': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
-            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'title': ('django.db.models.fields.CharField', [], {'max_length': '255'})
-        },
-        'widgy.contentpage': {
-            'Meta': {'ordering': "('_order',)", 'object_name': 'ContentPage', '_ormbases': ['pages.Page']},
-            'page_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['pages.Page']", 'unique': 'True', 'primary_key': 'True'}),
-            'root_node': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['widgy.Node']", 'null': 'True', 'on_delete': 'models.SET_NULL', 'blank': 'True'})
-        },
-        'widgy.imagecontent': {
-            'Meta': {'object_name': 'ImageContent'},
-            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'image': ('mezzanine.core.fields.FileField', [], {'max_length': '255'})
-        },
         'widgy.node': {
             'Meta': {'object_name': 'Node'},
             'content_id': ('django.db.models.fields.PositiveIntegerField', [], {}),
@@ -143,15 +41,6 @@ class Migration(SchemaMigration):
             'numchild': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
             'path': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'})
         },
-        'widgy.textcontent': {
-            'Meta': {'object_name': 'TextContent'},
-            'content': ('django.db.models.fields.TextField', [], {}),
-            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
-        },
-        'widgy.twocolumnlayout': {
-            'Meta': {'object_name': 'TwoColumnLayout'},
-            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
-        }
     }
 
     complete_apps = ['widgy']

--- a/widgy/migrations/0002_auto__del_imagecontent__del_twocolumnlayout__del_bucket__del_textconte.py
+++ b/widgy/migrations/0002_auto__del_imagecontent__del_twocolumnlayout__del_bucket__del_textconte.py
@@ -8,48 +8,11 @@ from django.db import models
 class Migration(SchemaMigration):
 
     def forwards(self, orm):
-        # Deleting model 'ImageContent'
-        db.delete_table('widgy_imagecontent')
-
-        # Deleting model 'TwoColumnLayout'
-        db.delete_table('widgy_twocolumnlayout')
-
-        # Deleting model 'Bucket'
-        db.delete_table('widgy_bucket')
-
-        # Deleting model 'TextContent'
-        db.delete_table('widgy_textcontent')
+        pass
 
 
     def backwards(self, orm):
-        # Adding model 'ImageContent'
-        db.create_table('widgy_imagecontent', (
-            ('image', self.gf('mezzanine.core.fields.FileField')(max_length=255)),
-            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
-        ))
-        db.send_create_signal('widgy', ['ImageContent'])
-
-        # Adding model 'TwoColumnLayout'
-        db.create_table('widgy_twocolumnlayout', (
-            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
-        ))
-        db.send_create_signal('widgy', ['TwoColumnLayout'])
-
-        # Adding model 'Bucket'
-        db.create_table('widgy_bucket', (
-            ('draggable', self.gf('django.db.models.fields.BooleanField')(default=True)),
-            ('title', self.gf('django.db.models.fields.CharField')(max_length=255)),
-            ('deletable', self.gf('django.db.models.fields.BooleanField')(default=True)),
-            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
-        ))
-        db.send_create_signal('widgy', ['Bucket'])
-
-        # Adding model 'TextContent'
-        db.create_table('widgy_textcontent', (
-            ('content', self.gf('django.db.models.fields.TextField')()),
-            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
-        ))
-        db.send_create_signal('widgy', ['TextContent'])
+        pass
 
 
     models = {


### PR DESCRIPTION
This pair of migrations created and then removed a bunch of stuff in Widgy that depended on Mezzanine. Removing each create/delete pair allows migrating Widgy without Mezzanine.
