### PR TITLE
Use a more realistic context to render pages for search

### DIFF
--- a/widgy/contrib/widgy_mezzanine/search_indexes.py
+++ b/widgy/contrib/widgy_mezzanine/search_indexes.py
@@ -27,7 +27,8 @@ class PageIndex(indexes.SearchIndex, indexes.Indexable):
         return self.get_model().objects.published()
 
     def prepare_text(self, obj):
-        html = render_root({}, obj, 'root_node')
+        context = {'_current_page': obj, 'page': obj.page_ptr}
+        html = render_root(context, obj, 'root_node')
         content = html_to_plaintext(html)
         keywords = ' '.join(self.prepare_keywords(obj))
         return ' '.join([obj.title, keywords, obj.description,


### PR DESCRIPTION
The Mezzanine page middleware adds a page and _current_page to the context for pages, so our search index should too.
