### PR TITLE
Capitalize option group names in LinkField choices

### DIFF
--- a/tests/modeltests/core_tests/tests/links.py
+++ b/tests/modeltests/core_tests/tests/links.py
@@ -95,14 +95,14 @@ class TestLinkForm(TestCase):
         form = LinkForm()
 
         self.assertEqual(form.fields['link'].choices, [
-            (AnotherLinkableThing._meta.verbose_name_plural, [
+            ('Another linkable things', [
                 convert_linkable_to_choice(page3),
             ]),
-            (LinkableThing._meta.verbose_name_plural, [
+            ('Linkable things', [
                 convert_linkable_to_choice(page2),
                 convert_linkable_to_choice(page1),
             ]),
-            (LinkableThing3._meta.verbose_name_plural, [
+            ('ZZZZZ should be last', [
                 convert_linkable_to_choice(page4),
             ]),
         ])

--- a/widgy/models/links.py
+++ b/widgy/models/links.py
@@ -3,6 +3,7 @@ import itertools
 
 from django.db import models
 from django.contrib.contenttypes.models import ContentType
+from django.template.defaultfilters import capfirst
 from django import forms
 
 from widgy.generic import WidgyGenericForeignKey
@@ -119,7 +120,7 @@ class LinkFormField(forms.ChoiceField):
     def populate_choices(self, choice_map):
         keyfn = lambda x: x[1].lower()
 
-        choices = [(Model._meta.verbose_name_plural,
+        choices = [(capfirst(Model._meta.verbose_name_plural),
                     sorted(map(convert_linkable_to_choice, choices), key=keyfn))
                    for Model, choices in choice_map
                    if len(choices)]


### PR DESCRIPTION
It looks nicer?
