### PR TITLE
Fix inheritance for LinkFields

### DIFF
--- a/tests/modeltests/core_tests/tests/links.py
+++ b/tests/modeltests/core_tests/tests/links.py
@@ -1,9 +1,11 @@
+import copy
+
 from django import forms
 from django.test import TestCase
 
 from widgy.models.links import (
     link_registry, get_link_field_from_model, LinkFormMixin, LinkFormField,
-    get_composite_key, convert_linkable_to_choice,
+    get_composite_key, convert_linkable_to_choice, LinkRegistry, LinkField
 )
 
 from modeltests.core_tests.models import (
@@ -19,6 +21,15 @@ class TestLinkField(TestCase):
         self.assertFalse(any(
             i.name == 'linkable_content_type' for i in ChildThingWithLink._meta.local_fields
         ))
+
+    def test_copy(self):
+        # a LinkField has a reference to a LinkRegistry. Copying the LinkField
+        # shouldn't copy the registry. Copying the field happens with model
+        # inheritance.
+        registry = LinkRegistry()
+        f1 = LinkField(link_registry=registry)
+        f2 = copy.deepcopy(f1)
+        self.assertIs(f1._link_registry, f2._link_registry)
 
 
 class TestLinkRelations(TestCase):

--- a/widgy/models/links.py
+++ b/widgy/models/links.py
@@ -1,7 +1,9 @@
+import copy
 from operator import or_
 import itertools
 
 from django.db import models
+from django.db.models.fields import Field
 from django.contrib.contenttypes.models import ContentType
 from django.template.defaultfilters import capfirst
 from django import forms
@@ -86,6 +88,12 @@ class LinkField(WidgyGenericForeignKey):
             cls.add_to_class(self.fk_field, fk_field)
 
         super(LinkField, self).contribute_to_class(cls, name)
+
+    def __deepcopy__(self, memodict):
+        # Copied from Field.__deepcopy__ to avoid copying _link_registry
+        obj = copy.copy(self)
+        memodict[id(self)] = obj
+        return obj
 
 
 def get_composite_key(linkable):


### PR DESCRIPTION
Don't copy the link_registry when copying a LinkField. When inheriting from a model with a LinkField, each field from the parent is deepcopied and attached to the child. This means that the child gets a different instance of its link_registry, and could not learn about models registered later.
