### PR TITLE
Preserve formfields' default widgets in widgy forms

### DIFF
--- a/widgy/contrib/form_builder/models.py
+++ b/widgy/contrib/form_builder/models.py
@@ -735,7 +735,7 @@ class FormInput(FormField):
             attrs['type'] = 'text'
             attrs['class'] = 'date auto-kal'
 
-        return forms.TextInput(attrs=attrs)
+        return self.formfield_class.widget(attrs=attrs)
 
 
 @widgy.register

--- a/widgy/contrib/form_builder/tests.py
+++ b/widgy/contrib/form_builder/tests.py
@@ -63,6 +63,17 @@ class GetFormTest(TestCase):
         self.assertTrue(isinstance(field, forms.CharField))
         self.assertEqual(field.label, 'Test')
 
+    def test_widget(self):
+        self.form = Form.add_root(widgy_site)
+
+        field_widget = self.form.children['fields'].add_child(widgy_site, FormInput,
+                                                              type='checkbox',
+                                                              label='Test',
+                                                              )
+        field = field_widget.get_formfield()
+
+        self.assertTrue(isinstance(field.widget, forms.CheckboxInput))
+
     def test_with_uncaptcha(self):
         uncaptcha = self.form.children['fields'].add_child(widgy_site, Uncaptcha)
         form_class = self.form.build_form_class()


### PR DESCRIPTION
Before, we were forcing all of them to TextInput. This breaks checkboxes, for example.
