### PR TITLE
Fixed global usage of $ in tabbed component

### DIFF
--- a/widgy/static/widgy/js/components/tabbed/component.js
+++ b/widgy/static/widgy/js/components/tabbed/component.js
@@ -1,4 +1,4 @@
-define([ 'underscore', 'widgy.backbone', 'components/widget/component' ], function(_, Backbone, widget) {
+define([ 'jquery', 'underscore', 'widgy.backbone', 'components/widget/component' ], function($, _, Backbone, widget) {
 
   var TabbedView = widget.View.extend({
     events: Backbone.extendEvents(widget.View, {


### PR DESCRIPTION
Tabbed component was using a global $, which was removed from grappelli-safe/mezzanine.
