### PR TITLE
Pass single error message as list instead of str

### DIFF
--- a/widgy/exceptions.py
+++ b/widgy/exceptions.py
@@ -25,7 +25,10 @@ class ParentChildRejection(InvalidTreeMovement):
     General exception for when a child rejects a parent or vice versa.
     """
     def __init__(self):
-        super(ParentChildRejection, self).__init__({'message': self.message})
+        # self.message gets passed within a list here because Django 1.6 doesn't
+        # support single strings being passed as error messages to ValidationError
+        # constructor. Once widgy stops supporting Django 1.6, this can be reverted.
+        super(ParentChildRejection, self).__init__({'message': [self.message]})
 
 
 class ParentWasRejected(ParentChildRejection):


### PR DESCRIPTION
In Django 1.6, ValidationError expects error messages to be passed
as dictionaries or lists. Passing in a single message as a string
results in the string being read as a list and each character
being used as a distinct error message.

This is fixed in Django 1.7.