### PR TITLE
Require django-compressor>=1.3 for django-pyscss.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ install_requires = [
     'six',
     'markdown',
     'bleach',
-    'django-compressor',
+    'django-compressor>=1.3',
     'django-extensions',
     'beautifulsoup4',
     'sorl-thumbnail==11.12',


### PR DESCRIPTION
Django-compressor 1.3 introduces the filter class functionality that
django-pyscss relies on.  django-pyscss doesn't require that version of
django-compressor because it is compressor agnostic.  It might be nice
to add an error into django-pyscss if django-compressor < 1.3 is
installed though.
