### PR TITLE
Allow RichTextPage in the Admin

### DIFF
--- a/docs/tutorials/widgy-mezzanine-tutorial.rst
+++ b/docs/tutorials/widgy-mezzanine-tutorial.rst
@@ -201,3 +201,31 @@ then set ``URLCONF_INCLUDE_CHOICES`` to a list of allowed urlpatterns. For examp
 
 .. _django-pyscss: https://github.com/fusionbox/django-pyscss
 .. _pyScss: https://github.com/Kronuz/pyScss
+
+Adding Widgy to Mezzanine
+-------------------------
+If you are adding widgy to an existing mezzanine site, there are
+some additional considerations.
+
+If you have existing mezzanine RichTextPages, you will need
+to reregister it. Simply create an admin.py file in your directory
+and add this code::
+
+    from django.contrib import admin
+
+    from mezzanine.pages.admin import PageAdmin
+    from mezzanine.pages.models import RichTextPage
+
+    admin.site.register(RichTextPage, PageAdmin)
+
+If you have not done so already, add the root directory of your mezzanine
+install to INSTALLED_APPS.
+
+Also, take care when setting the WIDGY_MEZZANINE_SITE variable in your
+settings.py file. Because mezzanine is using an old Django directory structure,
+it uses your root directory as your project file::
+
+    # Use:
+    WIDGY_MEZZANINE_SITE = 'myproject.demo.widgy_site.site'
+    # Not:
+    WIDGY_MEZZANINE_SITE = 'demo.widgy_site.site'


### PR DESCRIPTION
Here is the change for the issue brought up at the google group: https://groups.google.com/a/fusionbox.com/forum/#!topic/widgy/7t8TBTff3UM

I am not sure what @rockymeza is referring to: 

> (We need a way to remember to do this for all of our projects though.)

Does this create a problem for your existing accounts? 

I have a pull request at mezzanine for the other portion: https://github.com/stephenmcd/mezzanine/pull/1011

UPDATE: Stephen did not take the changes, ~~but with the changes @gavinwahl and @rockymeza discussed, Mezzanine does not seem to misbehave. Would it be ok if I update the QuickStart with the requirements to unhack a mezzanine install?~~
