### PR TITLE
Send the node/content data when repositioning

### DIFF
--- a/tests/modeltests/core_tests/tests/api.py
+++ b/tests/modeltests/core_tests/tests/api.py
@@ -399,13 +399,15 @@ class PermissionsTest(SwitchUserTestCase, RootNodeTestCase, HttpTestCase):
         left = self.root_node.content.add_child(self.widgy_site, Bucket)
         right = self.root_node.content.add_child(self.widgy_site, PickyBucket)
 
+        data = {
+            '__class__': 'core_tests.bucket',
+            'right_id': left.node.get_api_url(self.widgy_site),
+            'parent_id': self.root_node.get_api_url(self.widgy_site),
+        }
+
         def doit():
             url = right.node.get_api_url(self.widgy_site)
-            return self.put(url, {
-                '__class__': 'core_tests.bucket',
-                'right_id': left.node.get_api_url(self.widgy_site),
-                'parent_id': self.root_node.get_api_url(self.widgy_site),
-            })
+            return self.put(url, data)
 
         def fail():
             resp = doit()
@@ -418,6 +420,10 @@ class PermissionsTest(SwitchUserTestCase, RootNodeTestCase, HttpTestCase):
             self.assertEqual(resp.status_code, 200)
             self.assertEqual(list(Layout.objects.get().get_children()),
                              [right, left])
+
+            node_data = json.loads(resp.content)['node']
+            self.assertEqual(node_data['right_id'], data['right_id'])
+            self.assertEqual(node_data['parent_id'], data['parent_id'])
 
             # reset
             PickyBucket.objects.get().reposition(self.widgy_site, parent=self.root_node.content)

--- a/widgy/views/api.py
+++ b/widgy/views/api.py
@@ -147,7 +147,13 @@ class NodeView(WidgyView):
             except Node.DoesNotExist:
                 raise Http404
 
-        return self.render_as_node(None, status=200)
+        # We have to refetch before returning because treebeard doesn't
+        # update the in-memory instance, only the database, see
+        # <https://tabo.pe/projects/django-treebeard/docs/tip/caveats.html#raw-queries>
+        node = Node.objects.get(pk=node.pk)
+        node.prefetch_tree()
+
+        return self.render_as_node(node.to_json(self.site), status=200)
 
     def delete(self, request, node_pk):
         node = get_object_or_404(Node, pk=node_pk)


### PR DESCRIPTION
This allows the UI to update based on new data after the move. For example, widgets can change their `display_name`s based on their tree position.
