### PR TITLE
Updated quickstart to cover south migrations with easy_thumbnails

### DIFF
--- a/demo/settings.py
+++ b/demo/settings.py
@@ -188,3 +188,11 @@ WIDGY_MEZZANINE_SITE = 'demo.widgy.widgy_site'
 
 
 DATABASE_ENGINE = DATABASES['default']['ENGINE']
+
+# easy_thumbnails' versions 2.0+ changed their migrations
+import easy_thumbnails
+
+if easy_thumbnails.VERSION >= 2:
+    SOUTH_MIGRATION_MODULES = {
+        'easy_thumbnails': 'easy_thumbnails.south_migrations',
+    }

--- a/docs/tutorials/widgy-mezzanine-tutorial.rst
+++ b/docs/tutorials/widgy-mezzanine-tutorial.rst
@@ -117,6 +117,14 @@ Configure django-compressor::
     for ``text/x-scss``.  Widgy uses the django-pyscss_ package for easily
     integrating the pyScss_ library with Django.
 
+.. note::
+
+    With easy_thumbnails version 2.0+, an additional setting is required::
+
+    SOUTH_MIGRATION_MODULES = {
+        'easy_thumbnails': 'easy_thumbnails.south_migrations',
+    }
+
 syncdb; migrate
 
 add urls::

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -137,6 +137,14 @@ def setup(verbosity, test_labels):
     test_labels_set = set([label.split('.')[0] for label in test_labels])
     test_modules = get_test_modules()
 
+    # easy_thumbnails changes how it does migrations
+    import easy_thumbnails
+
+    if easy_thumbnails.VERSION >= 2:
+        SOUTH_MIGRATION_MODULES = {
+            'easy_thumbnails': 'easy_thumbnails.south_migrations',
+        }
+
     for module_dir, module_name in test_modules:
         module_label = '.'.join([module_dir, module_name])
         # if the module was named on the command line, or


### PR DESCRIPTION
Your call on whether this should make it into the documentation. I had set MySQL as the db backend, and the console did a good job flagging the issue during syncdb.
