### PR TITLE
Updated django-debug-toolbar in demo and made widgy page default

### DIFF
--- a/demo/settings.py
+++ b/demo/settings.py
@@ -90,17 +90,30 @@ GRAPPELLI_INSTALLED = True
 ADMIN_MEDIA_PREFIX = STATIC_URL + "grappelli/"
 SITE_ID = 1
 
-DEBUG_TOOLBAR_PANELS = (
-    'debug_toolbar.panels.version.VersionDebugPanel',
-    'debug_toolbar.panels.timer.TimerDebugPanel',
-    'debug_toolbar.panels.settings_vars.SettingsVarsDebugPanel',
-    'debug_toolbar.panels.headers.HeaderDebugPanel',
-    'debug_toolbar.panels.request_vars.RequestVarsDebugPanel',
-    'debug_toolbar.panels.template.TemplateDebugPanel',
-    'debug_toolbar.panels.sql.SQLDebugPanel',
-    'debug_toolbar.panels.signals.SignalDebugPanel',
-    'debug_toolbar.panels.logger.LoggingPanel',
-    'widgy.debugtoolbar.templates.TemplatePanel',
+import debug_toolbar
+
+if debug_toolbar.VERSION < 1:
+    DEBUG_TOOLBAR_PANELS = (
+        'debug_toolbar.panels.version.VersionDebugPanel',
+        'debug_toolbar.panels.timer.TimerDebugPanel',
+        'debug_toolbar.panels.settings_vars.SettingsVarsDebugPanel',
+        'debug_toolbar.panels.headers.HeaderDebugPanel',
+        'debug_toolbar.panels.request_vars.RequestVarsDebugPanel',
+        'debug_toolbar.panels.template.TemplateDebugPanel',
+        'debug_toolbar.panels.sql.SQLDebugPanel',
+        'debug_toolbar.panels.signals.SignalDebugPanel',
+        'debug_toolbar.panels.logger.LoggingPanel',
+        'widgy.debugtoolbar.templates.TemplatePanel',
+    )
+elif debug_toolbar.VERSION > '1.2.0':
+    DEBUG_TOOLBAR_PATCH_SETTINGS = False
+else:
+    raise ImportError('Your version of django_debug_toolbar is not supported.')
+
+INTERNAL_IPS = (
+    '127.0.0.1',
+    '208.186.116.206',
+    '208.186.142.130',
 )
 
 ROOT_URLCONF = 'demo.urls'
@@ -159,12 +172,6 @@ COMPRESS_PRECOMPILERS = (
     ('text/x-scss', 'django_pyscss.compressor.DjangoScssFilter'),
 )
 
-INTERNAL_IPS = (
-    '127.0.0.1',
-    '208.186.116.206',
-    '208.186.142.130',
-)
-
 ADMIN_MENU_ORDER = [
     ('Widgy', (
         'pages.Page',
@@ -173,6 +180,10 @@ ADMIN_MENU_ORDER = [
         ('Review queue', 'review_queue.ReviewedVersionCommit'),
     )),
 ]
+
+ADD_PAGE_ORDER = (
+    'widgy_mezzanine.WidgyPage',
+)
 
 URLCONF_INCLUDE_CHOICES = (
     ('demo.demo_url.urls', 'Demo url'),

--- a/demo/urls.py
+++ b/demo/urls.py
@@ -1,3 +1,5 @@
+import debug_toolbar
+
 from django.conf import settings
 from django.conf.urls import patterns, include, url
 from django.contrib import admin
@@ -55,19 +57,6 @@ urlpatterns = patterns("",
     # page tree in the admin if it was installed.
 
     # url("^$", "mezzanine.blog.views.blog_post_list", name="home"),
-
-    # MEZZANINE'S URLS
-    # ----------------
-    # Note: ADD YOUR OWN URLPATTERNS *ABOVE* THE LINE BELOW.
-    # ``mezzanine.urls`` INCLUDES A *CATCH ALL* PATTERN
-    # FOR PAGES, SO URLPATTERNS ADDED BELOW ``mezzanine.urls``
-    # WILL NEVER BE MATCHED!
-    # If you'd like more granular control over the patterns in
-    # ``mezzanine.urls``, go right ahead and take the parts you want
-    # from it, and use them directly below instead of using
-    # ``mezzanine.urls``.
-    ("^", include("mezzanine.urls")),
-
 )
 
 # Adds ``STATIC_URL`` to the context of error pages, so that error
@@ -80,3 +69,25 @@ if settings.DEBUG:
             'document_root': settings.MEDIA_ROOT,
         }),
     )
+
+    if debug_toolbar.VERSION > '1.2.0':
+        urlpatterns += patterns('',
+            url(r'^__debug__/', include(debug_toolbar.urls)),
+        )
+
+urlpatterns += patterns('',
+    # MEZZANINE'S URLS
+    # ----------------
+    # Note: ADD YOUR OWN URLPATTERNS *ABOVE* THE LINE BELOW.
+    # ``mezzanine.urls`` INCLUDES A *CATCH ALL* PATTERN
+    # FOR PAGES, SO URLPATTERNS ADDED BELOW ``mezzanine.urls``
+    # WILL NEVER BE MATCHED!
+    # If you'd like more granular control over the patterns in
+    # ``mezzanine.urls``, go right ahead and take the parts you want
+    # from it, and use them directly below instead of using
+    # ``mezzanine.urls``.
+
+    # Moved Mezzanine's URLS below Debug Toolbar because the catch-all
+    # interferes with Django Debug Toolbar's __debug__ url
+    ("^", include("mezzanine.urls")),
+)


### PR DESCRIPTION
Here is a request to update django-debug-toolbar in the widgy demo. I also added the `ADD_PAGE_ORDER` as well. I tested with 0.11.0, 1.2.0 (throws exception), and 1.2.1 to ensure it works across versions. 
