### PR TITLE
Moved many dependencies to extras_require

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ install: |
     pip install --upgrade pip
     pip install -q $DJANGO_PACKAGE --use-mirrors
     pip install -q --use-mirrors mock
+    pip install -q --use-mirrors South
 
     if [ "$DATABASE_ENGINE" = "mysql" ]
     then
@@ -36,7 +37,7 @@ install: |
     then
       pip install -q --use-mirrors psycopg2
     fi
-    pip install --use-mirrors .
+    pip install --use-mirrors -e .[page_builder,form_builder,widgy_mezzanine]
     pip freeze
   fi
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install: |
     then
       pip install -q --use-mirrors psycopg2
     fi
-    pip install --use-mirrors -e .[page_builder,form_builder,widgy_mezzanine]
+    pip install --use-mirrors -e .[all]
     pip freeze
   fi
 before_script:

--- a/docs/contrib/form-builder/index.rst
+++ b/docs/contrib/form-builder/index.rst
@@ -12,6 +12,21 @@ your :django:setting:`INSTALLED_APPS`.
 
 .. currentmodule:: widgy.contrib.form_builder.models
 
+Installation
+------------
+
+Form builder depends on the following packages:
+
+* django-widgy[page_builder]
+* django-extensions
+* html2text
+* phonenumbers
+
+You can install them manually, or you can install them using the django-widgy
+package::
+
+    $ pip install django-widgy[page_builder,form_builder]
+
 Success Handlers
 ----------------
 

--- a/docs/contrib/page-builder/index.rst
+++ b/docs/contrib/page-builder/index.rst
@@ -5,6 +5,25 @@ Page Builder
 
 Page builder is a collection of widgets for the purpose of creating HTML pages.
 
+Installation
+------------
+
+Page builder depends on the following packages:
+
+* django-filer
+* markdown
+* bleach
+* sorl-thumbnail
+
+You can install them manually, or you can install them using the django-widgy
+package::
+
+    $ pip install django-widgy[page_builder]
+
+
+Widgets
+-------
+
 
 .. class:: DefaultLayout
 

--- a/docs/contrib/widgy-mezzanine/index.rst
+++ b/docs/contrib/widgy-mezzanine/index.rst
@@ -7,6 +7,16 @@ providing a subclass of Mezzanine's Page model called
 :class:`~widgy.contrib.widgy_mezzanine.models.WidgyPage` which delegates to
 Page Builder for all content.
 
+The dependencies for Widgy Mezzanine (Mezzanine and Widgy's Page Builder app)
+are not installed by default when you install widgy, you can install them
+yourself::
+
+    $ pip install Mezzanine django-widgy[page_builder]
+
+or you can install them using through the widgy package::
+
+    $ pip install django-widgy[page_builder,widgy_mezzanine]
+
 In order to use Widgy Mezzanine, you must provide ``WIDGY_MEZZANINE_SITE`` in
 your settings.  This is a fully-qualified import path to an instance of
 :class:`~widgy.site.WidgySite`.  You also need to install the URLs. ::

--- a/docs/tutorials/widgy-mezzanine-tutorial.rst
+++ b/docs/tutorials/widgy-mezzanine-tutorial.rst
@@ -11,7 +11,7 @@ This quickstart assumes you wish to use the following packages:
 Install the Widgy package::
 
     cd widgy
-    pip install -e .
+    pip install -e .[all]
 
 Add Mezzanine apps to ``INSTALLED_APPS``::
 

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,8 @@ extras_require = {
     ],
 }
 
+extras_require['all'] = set(j for i in extras_require.values() for j in i)
+
 STAGE = 'alpha'
 
 version = (0, 3, 0, STAGE)

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ install_requires = [
     'mezzanine >= 1.3.0',
     'django-treebeard',
     'django-filer>=0.9.6',
-    'South',
     'django-pyscss',
     'six',
     'markdown',

--- a/setup.py
+++ b/setup.py
@@ -13,21 +13,30 @@ def read(fname):
 
 
 install_requires = [
-    'mezzanine >= 1.3.0',
     'django-treebeard',
-    'django-filer>=0.9.6',
     'django-pyscss',
     'six',
-    'markdown',
-    'bleach',
     'django-compressor>=1.3',
-    'django-extensions',
     'beautifulsoup4',
-    'sorl-thumbnail>=11.12',
-    'html2text>=3.200.3',
-    'phonenumbers>=5',
     'django-argonauts>=1.0.0',
 ]
+
+extras_require = {
+    'widgy_mezzanine': [
+        'mezzanine>=1.3.0',
+    ],
+    'page_builder': [
+        'django-filer>=0.9.6',
+        'markdown',
+        'bleach',
+        'sorl-thumbnail>=11.12',
+    ],
+    'form_builder': [
+        'django-extensions',
+        'html2text>=3.200.3',
+        'phonenumbers>=5',
+    ],
+}
 
 STAGE = 'alpha'
 
@@ -54,6 +63,7 @@ setup(
     url='http://docs.wid.gy/',
     packages=[package for package in find_packages() if package.startswith('widgy')],
     install_requires=install_requires,
+    extras_require=extras_require,
     zip_safe=False,
     include_package_data=True,
     classifiers=[

--- a/widgy/contrib/page_builder/db/fields.py
+++ b/widgy/contrib/page_builder/db/fields.py
@@ -12,11 +12,14 @@ from filer.models.filemodels import File
 
 from widgy.contrib.page_builder.forms import MarkdownField as MarkdownFormField, MarkdownWidget
 
-from south.modelsinspector import add_introspection_rules
-
-add_introspection_rules([], ["^widgy\.contrib\.page_builder\.db\.fields\.MarkdownField"])
-add_introspection_rules([], ["^widgy\.contrib\.page_builder\.db\.fields\.VideoField"])
-add_introspection_rules([], ["^widgy\.contrib\.page_builder\.db\.fields\.ImageField"])
+try:
+    from south.modelsinspector import add_introspection_rules
+except ImportError:  # South not installed
+    pass
+else:
+    add_introspection_rules([], ["^widgy\.contrib\.page_builder\.db\.fields\.MarkdownField"])
+    add_introspection_rules([], ["^widgy\.contrib\.page_builder\.db\.fields\.VideoField"])
+    add_introspection_rules([], ["^widgy\.contrib\.page_builder\.db\.fields\.ImageField"])
 
 
 class MarkdownField(models.TextField):

--- a/widgy/db/fields.py
+++ b/widgy/db/fields.py
@@ -9,10 +9,13 @@ from django.utils.functional import SimpleLazyObject
 from widgy.generic.models import ContentType as WidgyContentType
 from widgy.utils import fancy_import, update_context
 
-from south.modelsinspector import add_introspection_rules
-
-add_introspection_rules([], ["^widgy\.db.fields\.WidgyField"])
-add_introspection_rules([], ["^widgy\.db.fields\.VersionedWidgyField"])
+try:
+    from south.modelsinspector import add_introspection_rules
+except ImportError:  # South not installed
+    pass
+else:
+    add_introspection_rules([], ["^widgy\.db.fields\.WidgyField"])
+    add_introspection_rules([], ["^widgy\.db.fields\.VersionedWidgyField"])
 
 
 def get_site(site):

--- a/widgy/generic/__init__.py
+++ b/widgy/generic/__init__.py
@@ -3,11 +3,15 @@ from django.contrib.contenttypes import generic
 from django.db import DEFAULT_DB_ALIAS, connection
 from widgy.generic.models import ContentType
 
-from south.modelsinspector import add_ignored_fields
+try:
+    from south.modelsinspector import add_ignored_fields
+except ImportError:  # South not installed.
+    pass
+else:
+    add_ignored_fields(["^widgy\.generic\.ProxyGenericRelation",
+                        "^widgy\.generic\.ProxyGenericForeignKey",
+                        "^widgy\.generic\.WidgyGenericForeignKey"])
 
-add_ignored_fields(["^widgy\.generic\.ProxyGenericRelation",
-                    "^widgy\.generic\.ProxyGenericForeignKey",
-                    "^widgy\.generic\.WidgyGenericForeignKey"])
 
 if django.VERSION >= (1, 6):
     class ProxyGenericForeignKey(generic.GenericForeignKey):

--- a/widgy/templatetags/widgy_tags.py
+++ b/widgy/templatetags/widgy_tags.py
@@ -2,8 +2,6 @@ from django import template
 from django.conf import settings
 from django.utils.safestring import mark_safe
 
-import markdown
-
 from widgy.utils import fancy_import, update_context
 
 register = template.Library()
@@ -40,6 +38,7 @@ def js_files(site):
 
 @register.filter(name='markdown')
 def mdown(value):
+    import markdown
     value = markdown.markdown(
         value,
         extensions=['sane_lists'],


### PR DESCRIPTION
This is an attempt to resolve #218.

It's not ready to merge, as I didn't really know what to do about the site option for Callout.  I did something silly for now.  I created a minimalistic install of widgy[0] in order to test this out.  I wasn't sure how to go about doing it otherwise.  It has a couple of branches for the different dependency groups.

I also removed the dependency on South.

[0]: https://github.com/fusionbox/widgy-bare