### PR TITLE
preserve pip errors so travis reports install failures better

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
     - python: "2.7"
       env: JAVASCRIPT=1
 install: |
+  set -e
   if [ -z "$JAVASCRIPT" ]
   then
     pip install --upgrade pip


### PR DESCRIPTION
Sometimes the install script fails: https://travis-ci.org/fusionbox/django-widgy/jobs/28534786, but travis thinks it succeeded because bash.
