### PR TITLE
Remove view_instance from WidgyViewMixin.

### DIFF
--- a/docs/api/site.rst
+++ b/docs/api/site.rst
@@ -34,10 +34,6 @@ Widgy Site
 
       .. todo:: explain reverse
 
-    ..
-        Should this be public?
-        .. method:: get_view_instance(self, view)
-
     .. method:: authorize_view(self, request, view)
 
     Every Widgy view will call this before doing anything. It can

--- a/widgy/site.py
+++ b/widgy/site.py
@@ -68,12 +68,6 @@ class WidgySite(object):
         """
         return reverse(*args, **kwargs)
 
-    def get_view_instance(self, view):
-        try:
-            return view.view_instance
-        except AttributeError:
-            raise ValueError("View does not inherit from WidgyViewMixin")
-
     def authorize_view(self, request, view):
         if not request.user.is_authenticated():
             raise PermissionDenied

--- a/widgy/views/base.py
+++ b/widgy/views/base.py
@@ -4,12 +4,6 @@ class WidgyViewMixin(object):
     def auth(self, request, *args, **kwargs):
         self.site.authorize_view(request, self)
 
-    @classmethod
-    def as_view(cls, **initkwargs):
-        view_func = super(WidgyViewMixin, cls).as_view(**initkwargs)
-        view_func.view_instance = cls(**initkwargs)
-        return view_func
-
 
 class AuthorizedMixin(WidgyViewMixin):
     """


### PR DESCRIPTION
This was left over from how we were doing permissions for the Review
Queue before.  It is not being used anywhere now.

I just came across this, I thought we could clean up a little.
