### PR TITLE
Only pin minimum versions of our dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,10 +16,6 @@ install_requires = [
     'mezzanine >= 1.3.0',
     'django-treebeard',
     'django-filer>=0.9.5',
-    # We don't actually require polymorphic -- filer does. we do need to
-    # increase the minimum version though, to one that supports django
-    # 1.6.
-    'django_polymorphic>=0.5.1',
     'South',
     'django-pyscss',
     'six',


### PR DESCRIPTION
django-filer released 0.9.6 a couple days ago and any fresh installation of widgy should use it, also, django_polymorphic 0.5.5 has already been released, so I don't think we need to use the edge version just to install 0.5.1.

BTW, I found a cool pip trick to get a list of all old dependencies:

``` sh
$ pip list -o
```

It will show you all of the out-of-date dependencies of your projects.
