### PR TITLE
Only show interesting approve/unapprove buttons

### DIFF
--- a/widgy/contrib/review_queue/site.py
+++ b/widgy/contrib/review_queue/site.py
@@ -2,13 +2,14 @@ from django.conf.urls import patterns, url
 from django.utils.functional import cached_property
 
 from widgy.site import WidgySite
-from widgy.views import HistoryView, RevertView
+from widgy.views import RevertView
 
 from .views import (
     ApproveView,
     ReviewedCommitView,
     UnapproveView,
     UndoApprovalsView,
+    HistoryView,
 )
 
 

--- a/widgy/contrib/review_queue/templates/review_queue/history.html
+++ b/widgy/contrib/review_queue/templates/review_queue/history.html
@@ -35,7 +35,7 @@
 {% block commit_actions %}
   {{ block.super }}
   {% has_change_permission site commit.reviewedversioncommit as can_change %}
-  {% if can_change %}
+  {% if can_change and commit.is_interesting_to_approve_or_unapprove %}
     {% if not commit.reviewedversioncommit.is_approved %}
       <form method="post" action="{% reverse_site_url site 'approve_view' pk=commit.tracker.pk commit_pk=commit.pk %}">
         <input class="button approve" type="submit" value="{% trans "Approve this Commit" %}">


### PR DESCRIPTION
For old commits, approving or unapproving them won't actually do anything. Once we get to the first approved commits, we can stop showing the approve/unapprove buttons.
