### PR TITLE
widgy_mezzanine preview is broken for pages without slugs (while restoring a deleted page?)

### DIFF
--- a/widgy/contrib/widgy_mezzanine/views.py
+++ b/widgy/contrib/widgy_mezzanine/views.py
@@ -33,6 +33,7 @@ def get_page_from_node(node):
         return WidgyPage(
             titles='restoring page',
             content_model='widgypage',
+            slug='restoring-page',
         )
 
 
@@ -45,6 +46,7 @@ class PageViewMixin(object):
             return WidgyPage(
                 titles='restoring page',
                 content_model='widgypage',
+                slug='restoring-page',
             )
 
     def page_view(self, request, page, context):


### PR DESCRIPTION
Looks like mezzanine expects there to always be a slug:

```
Stacktrace (most recent call last):

  File "django/core/handlers/base.py", line 113, in get_response
    response = callback(request, *callback_args, **callback_kwargs)
  File "django/views/generic/base.py", line 68, in view
    return self.dispatch(request, *args, **kwargs)
  File "widgy/views/base.py", line 24, in dispatch
    return super(AuthorizedMixin, self).dispatch(*args, **kwargs)
  File "django/views/generic/base.py", line 86, in dispatch
    return handler(request, *args, **kwargs)
  File "widgy/contrib/widgy_mezzanine/views.py", line 109, in get
    return self.page_view(request, page, context)
  File "widgy/contrib/widgy_mezzanine/views.py", line 71, in page_view
    return page_view(request, page.slug, extra_context=extra_context)
  File "mezzanine/pages/views.py", line 100, in page
    return render(request, templates, extra_context or {})
  File "mezzanine/utils/views.py", line 163, in render
    context_instance = RequestContext(request, dictionary)
  File "django/template/context.py", line 179, in __init__
    self.update(processor(request))
  File "mezzanine/pages/context_processors.py", line 18, in page
    page.set_helpers(context)
  File "mezzanine/pages/models.py", line 266, in set_helpers
    self.html_id = self.slug.replace("/", "-")
```
