### PR TITLE
Add default children to Accordion and Tabs.

### DIFF
--- a/widgy/contrib/page_builder/models.py
+++ b/widgy/contrib/page_builder/models.py
@@ -9,7 +9,7 @@ from django.template.defaultfilters import truncatechars
 from widgy.models import Content
 from widgy.models.mixins import (
     StrictDefaultChildrenMixin, InvisibleMixin, StrDisplayNameMixin,
-    TabbedContainer,
+    TabbedContainer, DefaultChildrenMixin,
 )
 from widgy.models.links import LinkField, LinkFormField, LinkFormMixin
 from widgy.db.fields import WidgyField
@@ -196,7 +196,7 @@ class CalloutWidget(StrDisplayNameMixin, Content):
 
 
 @widgy.register
-class Accordion(Bucket):
+class Accordion(DefaultChildrenMixin, Bucket):
     draggable = True
     deletable = True
     tooltip = _("Accordions are a good way to separate sections of content. A"
@@ -209,6 +209,20 @@ class Accordion(Bucket):
     class Meta:
         verbose_name = _('accordion')
         verbose_name_plural = _('accordions')
+
+    @property
+    def default_children(self):
+        """
+        Adds 2 Sections as children because you would only ever use an
+        Accordion if you had 2 or more Sections.  This increases usability as
+        users now don't have to figure out what child Accordion accepts, they
+        can follow an example now.  Also, add default titles to the Sections to
+        let the user know that Sections need titles.
+        """
+        return [
+            (Section, (), {'title': _('Title 1')}),
+            (Section, (), {'title': _('Title 2')}),
+        ]
 
 
 @widgy.register

--- a/widgy/contrib/page_builder/tests.py
+++ b/widgy/contrib/page_builder/tests.py
@@ -5,8 +5,10 @@ from widgy.site import WidgySite
 from widgy.models import Node
 from widgy.exceptions import ParentChildRejection
 
-from widgy.contrib.page_builder.models import (Table, TableRow,
-        TableHeaderData, TableHeader, TableBody)
+from widgy.contrib.page_builder.models import (
+    Table, TableRow, TableHeaderData, TableHeader, TableBody,
+    Accordion,
+)
 from widgy.contrib.page_builder.forms import CKEditorField
 
 
@@ -217,3 +219,11 @@ class TestHtmlCleaning(TestCase):
         for html, must_not_occur in test_cases:
             cleaned = CKEditorField().clean(html)
             self.assertNotIn(must_not_occur, cleaned)
+
+
+class TestAccordionAutomaticallyAdds2Sections(TestCase):
+    def test_adding_new_accordion_is_user_friendly(self):
+        tabs = Accordion.add_root(widgy_site)
+        self.assertEqual(len(tabs.get_children()), 2)
+        self.assertEqual(tabs.get_children()[0].title, 'Title 1')
+        self.assertEqual(tabs.get_children()[1].title, 'Title 2')


### PR DESCRIPTION
This improves usability by letting the user know what you are supposed
to put in Accordions (and Tabs) and also by letting know that Sections
need titles.
