### PR TITLE
Deprecate **kwargs for add_root etc, use a dictionary instead

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,10 @@ Changelog
 
 .. _django-pyscss: https://github.com/fusionbox/django-pyscss
 
+* ``Content.add_root``, ``add_child``, and ``add_sibling`` take an attrs
+  dictionary instead of `**kwargs`. Passing kwargs is deprecated but still
+  supported.
+
 0.1.6 (2014-09-09)
 ------------------------
 * Fix migrations containing unsupported KeywordsField from mezzanine [Scott Clark]

--- a/docs/api/models.rst
+++ b/docs/api/models.rst
@@ -45,16 +45,16 @@ Base Models
         # move the sidebar to the left of the main content.
         >>> sidebar.reposition(widgy_site, right=main)
 
-    .. classmethod:: add_root(cls, site, **kwargs)
+    .. classmethod:: add_root(cls, site, attrs={})
 
-        Creates a root node widget.  Any kwargs will be passed to the Content
+        Creates a root node widget.  Any attrs will be passed to the Content
         class's initialize method. ::
 
-    .. method:: add_child(self, site, cls, **kwargs)
+    .. method:: add_child(self, site, cls, attrs={})
 
         Adds a new instance of ``cls`` as the last child of the current widget.
 
-    .. method:: add_sibling(self, site, cls, **kwargs)
+    .. method:: add_sibling(self, site, cls, attrs={})
 
         Adds a new instance of ``cls`` to the right of the current widget.
 

--- a/tests/modeltests/core_tests/tests/api.py
+++ b/tests/modeltests/core_tests/tests/api.py
@@ -229,8 +229,9 @@ class TestApi(RootNodeTestCase, HttpTestCase):
         doit('delete')
 
     def test_delete_undeletable(self):
-        node = UndeletableRawTextWidget.add_root(self.widgy_site,
-                                                 text='asdf').node
+        node = UndeletableRawTextWidget.add_root(self.widgy_site, {
+            'text': 'asdf',
+        }).node
 
         resp = self.delete(node.get_api_url(self.widgy_site))
         self.assertEqual(resp.status_code, 409)

--- a/tests/modeltests/core_tests/tests/base.py
+++ b/tests/modeltests/core_tests/tests/base.py
@@ -121,28 +121,28 @@ def display_node(node):
 
 def make_a_nice_tree(root_node, widgy_site=widgy_site):
     left, right = root_node.content.get_children()
-    left.add_child(widgy_site,
-                   RawTextWidget,
-                   text='left_1')
-    left.add_child(widgy_site,
-                   RawTextWidget,
-                   text='left_2')
+    left.add_child(widgy_site, RawTextWidget, {
+        'text': 'left_1',
+    })
+    left.add_child(widgy_site, RawTextWidget, {
+        'text': 'left_2',
+    })
 
     subbucket = left.add_child(widgy_site,
                                Bucket)
-    subbucket.add_child(widgy_site,
-                        RawTextWidget,
-                        text='subbucket_1')
-    subbucket.add_child(widgy_site,
-                        RawTextWidget,
-                        text='subbucket_2')
+    subbucket.add_child(widgy_site, RawTextWidget, {
+        'text': 'subbucket_1',
+    })
+    subbucket.add_child(widgy_site, RawTextWidget, {
+        'text': 'subbucket_2',
+    })
 
-    right.add_child(widgy_site,
-                    RawTextWidget,
-                    text='right_1')
-    right.add_child(widgy_site,
-                    RawTextWidget,
-                    text='right_2')
+    right.add_child(widgy_site, RawTextWidget, {
+        'text': 'right_1',
+    })
+    right.add_child(widgy_site, RawTextWidget, {
+        'text': 'right_2',
+    })
 
     return left.node, right.node
 

--- a/tests/modeltests/core_tests/tests/core.py
+++ b/tests/modeltests/core_tests/tests/core.py
@@ -53,8 +53,7 @@ class TestCore(RootNodeTestCase):
         """
         content = self.root_node.content
         for i in range(50):
-            content = content.add_child(self.widgy_site,
-                                        Bucket)
+            content = content.add_child(self.widgy_site, Bucket)
 
         # + 2 -- original buckets
         self.assertEqual(len(self.root_node.get_descendants()), 50 + 2)
@@ -75,17 +74,16 @@ class TestCore(RootNodeTestCase):
                                                         PickyBucket)
 
         with self.assertRaises(ChildWasRejected):
-            picky_bucket.add_child(self.widgy_site,
-                                   RawTextWidget,
-                                   text='aasdf')
+            picky_bucket.add_child(self.widgy_site, RawTextWidget, {
+                'text': 'aasdf',
+            })
 
-        picky_bucket.add_child(self.widgy_site,
-                               RawTextWidget,
-                               text='hello')
+        picky_bucket.add_child(self.widgy_site, RawTextWidget, {
+            'text': 'hello',
+        })
 
         with self.assertRaises(ChildWasRejected):
-            picky_bucket.add_child(self.widgy_site,
-                                   Layout)
+            picky_bucket.add_child(self.widgy_site, Layout)
 
     def test_reposition_rechecks_deep_deep_compatibility(self):
         a = self.root_node.content.add_child(widgy_site, UnnestableWidget)
@@ -255,8 +253,8 @@ class TestCore(RootNodeTestCase):
             (ForeignKeyWidget, {'foo': r}, {'foo_id': r.pk}),
         ]
 
-        for cls, kwargs, attributes in tests:
-            widget = cls.add_root(self.widgy_site, **kwargs)
+        for cls, attrs, attributes in tests:
+            widget = cls.add_root(self.widgy_site, attrs)
             self.assertEqual(widget.get_attributes(),
                              attributes)
 
@@ -309,41 +307,41 @@ class TestTreesEqual(RootNodeTestCase):
 
     def test_trees_unequal_content_type(self):
         a = CantGoAnywhereWidget.add_root(self.widgy_site)
-        b = RawTextWidget.add_root(self.widgy_site, text='a')
+        b = RawTextWidget.add_root(self.widgy_site, {'text': 'a'})
 
         self.assertFalse(a.node.trees_equal(b.node))
 
     def test_trees_unequal_children(self):
         a = Bucket.add_root(self.widgy_site)
-        a.add_child(self.widgy_site, RawTextWidget, text='a')
-        a.add_child(self.widgy_site, RawTextWidget, text='b')
+        a.add_child(self.widgy_site, RawTextWidget, {'text': 'a'})
+        a.add_child(self.widgy_site, RawTextWidget, {'text': 'b'})
 
         b = Bucket.add_root(self.widgy_site)
-        b.add_child(self.widgy_site, RawTextWidget, text='a')
+        b.add_child(self.widgy_site, RawTextWidget, {'text': 'a'})
 
         self.assertFalse(a.node.trees_equal(b.node))
 
     def test_trees_unequal_depth(self):
-        a = Bucket.add_root(self.widgy_site).add_child(self.widgy_site, RawTextWidget, text='a')
-        b = RawTextWidget.add_root(self.widgy_site, text='a')
+        a = Bucket.add_root(self.widgy_site).add_child(self.widgy_site, RawTextWidget, {'text': 'a'})
+        b = RawTextWidget.add_root(self.widgy_site, {'text': 'a'})
 
         self.assertFalse(a.node.trees_equal(b.node))
 
     def test_trees_unequal_content(self):
-        a = RawTextWidget.add_root(self.widgy_site, text='b')
-        b = RawTextWidget.add_root(self.widgy_site, text='a')
+        a = RawTextWidget.add_root(self.widgy_site, {'text': 'b'})
+        b = RawTextWidget.add_root(self.widgy_site, {'text': 'a'})
 
         self.assertFalse(a.node.trees_equal(b.node))
 
     def test_trees_equal_equal(self):
-        a = RawTextWidget.add_root(self.widgy_site, text='a')
-        b = RawTextWidget.add_root(self.widgy_site, text='a')
+        a = RawTextWidget.add_root(self.widgy_site, {'text': 'a'})
+        b = RawTextWidget.add_root(self.widgy_site, {'text': 'a'})
 
         self.assertTrue(a.node.trees_equal(b.node))
 
 
 def make_tracker(site, vt_class=VersionTracker):
-    root_node = RawTextWidget.add_root(widgy_site, text='first').node
+    root_node = RawTextWidget.add_root(widgy_site, {'text': 'first'}).node
     tracker = vt_class.objects.create(working_copy=root_node)
     return tracker
 
@@ -379,8 +377,8 @@ class TestVersioning(RootNodeTestCase):
 
     def test_clone_tree_uses_prefetch(self):
         root = Bucket.add_root(self.widgy_site)
-        root.add_child(self.widgy_site, RawTextWidget, text='a')
-        root.add_child(self.widgy_site, RawTextWidget, text='b')
+        root.add_child(self.widgy_site, RawTextWidget, {'text': 'a'})
+        root.add_child(self.widgy_site, RawTextWidget, {'text': 'b'})
 
         root_node = root.node
         root_node.prefetch_tree()
@@ -393,8 +391,8 @@ class TestVersioning(RootNodeTestCase):
             root_node.clone_tree()
 
     def test_content_equal(self):
-        a = RawTextWidget.add_root(self.widgy_site, text='a')
-        b = RawTextWidget.add_root(self.widgy_site, text='b')
+        a = RawTextWidget.add_root(self.widgy_site, {'text': 'a'})
+        b = RawTextWidget.add_root(self.widgy_site, {'text': 'b'})
         self.assertFalse(a.equal(b))
         b.text = 'a'
         b.save()
@@ -406,7 +404,7 @@ class TestVersioning(RootNodeTestCase):
         self.assertTrue(a.equal(b))
 
     def test_commit(self):
-        root_node = RawTextWidget.add_root(self.widgy_site, text='first').node
+        root_node = RawTextWidget.add_root(self.widgy_site, {'text': 'first'}).node
         tracker = VersionTracker.objects.create(working_copy=root_node)
         commit1 = tracker.commit()
 
@@ -425,14 +423,12 @@ class TestVersioning(RootNodeTestCase):
 
     def test_tree_structure_versioned(self):
         root_node = Bucket.add_root(self.widgy_site).node
-        root_node.content.add_child(
-            self.widgy_site,
-            RawTextWidget,
-            text='a')
-        root_node.content.add_child(
-            self.widgy_site,
-            RawTextWidget,
-            text='b')
+        root_node.content.add_child(self.widgy_site, RawTextWidget, {
+            'text': 'a',
+        })
+        root_node.content.add_child(self.widgy_site, RawTextWidget, {
+            'text': 'b',
+        })
 
         # if the root_node isn't refetched, get_children is somehow empty. I
         # don't know why
@@ -450,7 +446,7 @@ class TestVersioning(RootNodeTestCase):
                          [i.content.text for i in commit2.root_node.get_children()])
 
     def test_revert(self):
-        root_node = RawTextWidget.add_root(self.widgy_site, text='first').node
+        root_node = RawTextWidget.add_root(self.widgy_site, {'text': 'first'}).node
         tracker = VersionTracker.objects.create(working_copy=root_node)
         commit1 = tracker.commit()
 
@@ -473,7 +469,7 @@ class TestVersioning(RootNodeTestCase):
                          [i.root_node.content.text for i in tracker.get_history()])
 
     def test_get_history(self):
-        root_node = RawTextWidget.add_root(self.widgy_site, text='first').node
+        root_node = RawTextWidget.add_root(self.widgy_site, {'text': 'first'}).node
         tracker = VersionTracker.objects.create(working_copy=root_node)
 
         commits = reversed([tracker.commit() for i in range(6)])
@@ -481,7 +477,7 @@ class TestVersioning(RootNodeTestCase):
         self.assertSequenceEqual(list(tracker.get_history()), list(commits))
 
     def test_old_contents_cant_change(self):
-        root_node = RawTextWidget.add_root(self.widgy_site, text='first').node
+        root_node = RawTextWidget.add_root(self.widgy_site, {'text': 'first'}).node
         tracker = VersionTracker.objects.create(working_copy=root_node)
         commit = tracker.commit()
 
@@ -497,8 +493,12 @@ class TestVersioning(RootNodeTestCase):
 
     def test_old_structure_cant_change(self):
         root_node = Bucket.add_root(self.widgy_site).node
-        root_node.content.add_child(self.widgy_site, RawTextWidget, text='a')
-        root_node.content.add_child(self.widgy_site, RawTextWidget, text='b')
+        root_node.content.add_child(self.widgy_site, RawTextWidget, {
+            'text': 'a',
+        })
+        root_node.content.add_child(self.widgy_site, RawTextWidget, {
+            'text': 'b',
+        })
         root_node = Node.objects.get(pk=root_node.pk)
         tracker = VersionTracker.objects.create(working_copy=root_node)
         commit = tracker.commit()
@@ -508,7 +508,9 @@ class TestVersioning(RootNodeTestCase):
             b.reposition(self.widgy_site, right=a)
 
         with self.assertRaises(InvalidOperation):
-            commit.root_node.content.add_child(self.widgy_site, RawTextWidget, text='c')
+            commit.root_node.content.add_child(self.widgy_site, RawTextWidget, {
+                'text': 'c',
+            })
 
         self.assertEqual([i.content.text for i in commit.root_node.get_children()],
                          ['a', 'b'])
@@ -572,10 +574,14 @@ class TestVersioning(RootNodeTestCase):
             right.content.reposition(self.widgy_site, right=left.content)
 
         with self.assertRaises(InvalidOperation):
-            right.content.add_child(self.widgy_site, RawTextWidget, text='asdf')
+            right.content.add_child(self.widgy_site, RawTextWidget, {
+                'text': 'asdf',
+            })
 
         with self.assertRaises(InvalidOperation):
-            right.content.get_children()[0].add_sibling(self.widgy_site, RawTextWidget, text='asdf')
+            right.content.get_children()[0].add_sibling(self.widgy_site, RawTextWidget, {
+                'text': 'asdf',
+            })
 
         root_node = Node.objects.get(pk=self.root_node.id)
         self.assertEqual([i.id for i in root_node.depth_first_order()],
@@ -606,7 +612,7 @@ class TestVersioning(RootNodeTestCase):
             b.delete()
 
     def test_prefetch_commits(self):
-        root_node = RawTextWidget.add_root(self.widgy_site, text='first').node
+        root_node = RawTextWidget.add_root(self.widgy_site, {'text': 'first'}).node
         tracker = VersionTracker.objects.create(working_copy=root_node)
         user = User.objects.create()
         commits = reversed([tracker.commit(user=user) for i in range(6)])
@@ -706,7 +712,7 @@ class TestVersioning(RootNodeTestCase):
         """
 
         related = Related.objects.create()
-        root_node = ForeignKeyWidget.add_root(self.widgy_site, foo=related).node
+        root_node = ForeignKeyWidget.add_root(self.widgy_site, {'foo': related}).node
         tracker = VersionTracker.objects.create(working_copy=root_node)
         commit = tracker.commit()
 
@@ -725,7 +731,9 @@ class TestVersioning(RootNodeTestCase):
         # do the deletion on something other than the root node
         related = Related.objects.create()
         root_node = Bucket.add_root(self.widgy_site).node
-        root_node.content.add_child(self.widgy_site, ForeignKeyWidget, foo=related)
+        root_node.content.add_child(self.widgy_site, ForeignKeyWidget, {
+            'foo': related,
+        })
         root_node = Node.objects.get(pk=root_node.pk)
         tracker = VersionTracker.objects.create(working_copy=root_node)
         commit = tracker.commit()
@@ -755,7 +763,9 @@ class TestVersioning(RootNodeTestCase):
         self.assertTrue(vt.has_changes())
         vt.commit()
         self.assertFalse(vt.has_changes())
-        left.content.add_child(self.widgy_site, RawTextWidget, text='foo')
+        left.content.add_child(self.widgy_site, RawTextWidget, {
+            'text': 'foo',
+        })
         vt = VersionTracker.objects.get(pk=vt.pk)
         self.assertTrue(vt.has_changes())
 
@@ -787,7 +797,7 @@ class TestVersioning(RootNodeTestCase):
         self.assertIn(b, diff)
 
     def test_reset(self):
-        root_node = RawTextWidget.add_root(self.widgy_site, text='first').node
+        root_node = RawTextWidget.add_root(self.widgy_site, {'text': 'first'}).node
         tracker = VersionTracker.objects.create(working_copy=root_node)
         commit1 = tracker.commit()
 
@@ -849,7 +859,7 @@ class TestVersioning(RootNodeTestCase):
         self.assertNotEqual(new_root.pk, root.pk)
 
     def test_cloning_multi_table_inheritance_fancy(self):
-        root = WeirdPkBucket.add_root(self.widgy_site, bubble=2)
+        root = WeirdPkBucket.add_root(self.widgy_site, {'bubble': 2})
         new_root = root.clone()
         self.assertNotEqual(new_root.pk, root.pk)
 

--- a/tests/modeltests/core_tests/tests/fields.py
+++ b/tests/modeltests/core_tests/tests/fields.py
@@ -279,7 +279,7 @@ class TestRender(TestCase):
         self.widgied = HasAWidgy()
         self.widgied.widgy = Layout.add_root(widgy_site).node
         self.widgied.save()
-        self.widgied.widgy.get_children()[1].content.add_child(widgy_site, RawTextWidget, text='asdf')
+        self.widgied.widgy.get_children()[1].content.add_child(widgy_site, RawTextWidget, {'text': 'asdf'})
 
         self.widgy_field = HasAWidgy._meta.get_field_by_name('widgy')[0]
 

--- a/tests/modeltests/core_tests/tests/reviewqueue.py
+++ b/tests/modeltests/core_tests/tests/reviewqueue.py
@@ -21,7 +21,7 @@ from modeltests.core_tests.widgy_config import widgy_site
 
 
 def make_tracker(site, vt_class=ReviewedVersionTracker):
-    root_node = RawTextWidget.add_root(site, text='first').node
+    root_node = RawTextWidget.add_root(site, {'text': 'first'}).node
     tracker = vt_class.objects.create(working_copy=root_node)
     return tracker
 

--- a/tests/modeltests/core_tests/tests/templates.py
+++ b/tests/modeltests/core_tests/tests/templates.py
@@ -30,8 +30,9 @@ class TestTemplate(TestCase):
         return t.render(c)
 
     def plain_model(self):
-        node = RawTextWidget.add_root(widgy_site,
-                                      text=self.string_to_look_for).node
+        node = RawTextWidget.add_root(widgy_site, {
+            'text': self.string_to_look_for,
+        }).node
         return HasAWidgy.objects.create(
             widgy=node,
         )
@@ -45,7 +46,7 @@ class TestTemplate(TestCase):
         owner = self.plain_model()
 
         override_string = uuid.uuid4().hex
-        override = RawTextWidget.add_root(widgy_site, text=override_string).node
+        override = RawTextWidget.add_root(widgy_site, {'text': override_string}).node
 
         rendered = self.render({'owner': owner, 'field_name': 'widgy', 'root_node_override': override})
 
@@ -53,8 +54,9 @@ class TestTemplate(TestCase):
         self.assertIn(override_string, rendered)
 
     def versioned_model(self):
-        node = RawTextWidget.add_root(widgy_site,
-                                      text=self.string_to_look_for).node
+        node = RawTextWidget.add_root(widgy_site, {
+            'text': self.string_to_look_for,
+        }).node
         vt = VersionTracker.objects.create(working_copy=node)
         vt.commit()
 
@@ -71,7 +73,7 @@ class TestTemplate(TestCase):
         owner = self.versioned_model()
 
         override_string = uuid.uuid4().hex
-        override = RawTextWidget.add_root(widgy_site, text=override_string).node
+        override = RawTextWidget.add_root(widgy_site, {'text': override_string}).node
 
         rendered = self.render({'owner': owner, 'field_name': 'version_tracker', 'root_node_override': override})
 

--- a/widgy/contrib/form_builder/tests.py
+++ b/widgy/contrib/form_builder/tests.py
@@ -67,10 +67,10 @@ class GetFormTest(TestCase):
     def test_widget(self):
         self.form = Form.add_root(widgy_site)
 
-        field_widget = self.form.children['fields'].add_child(widgy_site, FormInput,
-                                                              type='checkbox',
-                                                              label='Test',
-                                                              )
+        field_widget = self.form.children['fields'].add_child(widgy_site, FormInput, {
+            'type': 'checkbox',
+            'label': 'Test',
+        })
         field = field_widget.get_formfield()
 
         self.assertTrue(isinstance(field.widget, forms.CheckboxInput))
@@ -93,14 +93,17 @@ class TestForm(TestCase):
     def make_form(self):
         form = Form.add_root(widgy_site)
         fields = []
-        fields.append(form.children['fields'].add_child(widgy_site, FormInput,
-                                                        label='field 1',
-                                                        type='text'))
-        fields.append(form.children['fields'].add_child(widgy_site, FormInput,
-                                                        label='field 2',
-                                                        type='text'))
-        fields.append(form.children['fields'].add_child(widgy_site, Textarea,
-                                                        label='field 3',))
+        fields.append(form.children['fields'].add_child(widgy_site, FormInput, {
+            'label': 'field 1',
+            'type': 'text'
+        }))
+        fields.append(form.children['fields'].add_child(widgy_site, FormInput, {
+            'label': 'field 2',
+            'type': 'text',
+        }))
+        fields.append(form.children['fields'].add_child(widgy_site, Textarea, {
+            'label': 'field 3',
+        }))
         return form, fields
 
     def setUp(self):
@@ -273,8 +276,9 @@ class TestForm(TestCase):
 
     def test_serialize_file_field(self):
         form = Form.add_root(widgy_site)
-        file_field = form.children['fields'].add_child(widgy_site, FileUpload,
-                                                       required=False)
+        file_field = form.children['fields'].add_child(widgy_site, FileUpload, {
+        'required': False,
+        })
 
         FormSubmission.objects.submit(form=form, data={
             file_field.get_formfield_name(): ContentFile(b'foobar', name='asdf.txt'),

--- a/widgy/contrib/widgy_mezzanine/tests.py
+++ b/widgy/contrib/widgy_mezzanine/tests.py
@@ -55,11 +55,11 @@ class TestFormHandler(TestCase):
         self.assertIs(resp, form_execute.return_value)
 
     def test_post_rerender(self):
-        self.form.children['fields'].add_child(widgy_site, FormInput,
-                                               label='foo',
-                                               required=True,
-                                               type='text',
-                                               )
+        self.form.children['fields'].add_child(widgy_site, FormInput, {
+            'label': 'foo',
+            'required': True,
+            'type': 'text',
+        })
 
         req = self.factory.post('/?from=/foo/')
         req.user = User(is_superuser=True)
@@ -95,11 +95,11 @@ class TestFormHandler(TestCase):
         from widgy.contrib.widgy_mezzanine.models import WidgyPage
         page = WidgyPage.objects.create(title='Test')
 
-        self.form.children['fields'].add_child(widgy_site, FormInput,
-                                               label='foo',
-                                               required=True,
-                                               type='text',
-                                               )
+        self.form.children['fields'].add_child(widgy_site, FormInput, {
+            'label': 'foo',
+            'required': True,
+            'type': 'text',
+        })
 
         req = self.factory.post('/?from=/foo/')
         req.user = User(is_superuser=True)
@@ -122,8 +122,8 @@ class TestPreviewView(TestCase):
 
     def test_preview(self):
         page = WidgyPage.objects.create(title='Test')
-        root_node1 = Button.add_root(widgy_site, text='Test 1')
-        root_node2 = Button.add_root(widgy_site, text='Test 2')
+        root_node1 = Button.add_root(widgy_site, {'text': 'Test 1'})
+        root_node2 = Button.add_root(widgy_site, {'text': 'Test 2'})
 
         resp1 = self.preview_view(self.request, node_pk=root_node1.node.pk, slug=page.slug)
 
@@ -137,7 +137,7 @@ class TestPreviewView(TestCase):
         self.assertIn('Test 2', resp2.rendered_content)
 
     def test_preview_without_page(self):
-        button = Button.add_root(widgy_site, text='Button text')
+        button = Button.add_root(widgy_site, {'text': 'Button text'})
 
         resp = self.preview_view(self.request, node_pk=button.node.pk)
         self.assertIn(button.text, resp.rendered_content)

--- a/widgy/db/fields.py
+++ b/widgy/db/fields.py
@@ -63,9 +63,9 @@ class WidgyField(models.ForeignKey):
         super(WidgyField, self).contribute_to_class(cls, name)
         setattr(cls, self.name, WidgyFieldObjectDescriptor(self))
 
-    def add_root(self, model_instance, root_content_kwargs={}):
+    def add_root(self, model_instance, attrs={}):
         value = getattr(model_instance, self.name)
-        return value._ct.model_class().add_root(self.site, **root_content_kwargs).node
+        return value._ct.model_class().add_root(self.site, attrs).node
 
     def pre_save(self, model_instance, add):
         """

--- a/widgy/models/mixins.py
+++ b/widgy/models/mixins.py
@@ -22,8 +22,8 @@ class DefaultChildrenMixin(object):
     default_children = tuple()
 
     def post_create(self, site):
-        for cls, args, kwargs in self.default_children:
-            self.add_child(site, cls, *args, **kwargs)
+        for cls, args, attrs in self.default_children:
+            self.add_child(site, cls, attrs, *args)
 
 
 class StrictDefaultChildrenMixin(DefaultChildrenMixin):
@@ -41,8 +41,8 @@ class StrictDefaultChildrenMixin(DefaultChildrenMixin):
         ]
     """
     def post_create(self, site):
-        for name, cls, args, kwargs in self.default_children:
-            self.add_child(site, cls, *args, **kwargs)
+        for name, cls, args, attrs in self.default_children:
+            self.add_child(site, cls, attrs, *args)
 
     @property
     def children(self):


### PR DESCRIPTION
I'm pretty sure I had a good reason for this, but I'm not sure exactly what it was.
