### PR TITLE
Fix ReviewedVersionTrackerQuerySet.published

### DIFF
--- a/tests/modeltests/core_tests/tests/reviewqueue.py
+++ b/tests/modeltests/core_tests/tests/reviewqueue.py
@@ -251,3 +251,16 @@ class ReviewQueueViewsTest(SwitchUserTestCase, RootNodeTestCase):
         commit2.approve(self.user)
         self.assertIn(tracker, vt_class.objects.published())
         self.assertIn(tracker2, vt_class.objects.published())
+
+    def test_published_stickiness(self):
+        vt_class = self.widgy_site.get_version_tracker_model()
+        tracker = make_tracker(self.widgy_site, vt_class)
+
+        # One commit is published, the other is approved. Since the same commit
+        # is not both published and approved, the tracker is not published.
+
+        c1 = tracker.commit(publish_at=timezone.now() + datetime.timedelta(days=1))
+        c1.approve(self.user)
+
+        tracker.commit(publish_at=timezone.now())
+        self.assertNotIn(tracker, vt_class.objects.published())

--- a/widgy/contrib/review_queue/models.py
+++ b/widgy/contrib/review_queue/models.py
@@ -50,10 +50,14 @@ class ReviewedVersionTracker(VersionTracker):
 
     class ReviewedVersionTrackerQuerySet(VersionTracker.VersionTrackerQuerySet):
         def published(self):
-            commits = super(ReviewedVersionTracker.ReviewedVersionTrackerQuerySet, self).published()
-            return commits.filter(commits__reviewedversioncommit__approved_by__isnull=False,
-                                  commits__reviewedversioncommit__approved_at__isnull=False)\
-                    .distinct()
+            return self.filter(
+                commits__reviewedversioncommit__approved_by__isnull=False,
+                commits__reviewedversioncommit__approved_at__isnull=False,
+                # we must put this condition here instead of calling
+                # super().published, because all of the conditions must be in
+                # the same call to filter().
+                commits__publish_at__lte=timezone.now(),
+            ).distinct()
 
     objects = ReviewedVersionTrackerQuerySet.as_manager()
 


### PR DESCRIPTION
All of the published conditions must be in the same call to filter, so we can't call super(). Otherwise if the tracker has a commit that is published but not approved, and another commit that is approved but not
published, the tracker will be counted as published even though no one of its commits is.

See https://docs.djangoproject.com/en/dev/topics/db/queries/#spanning-multi-valued-relationships for the difference.

The other option would be to try to use the undocumented _next_is_sticky() method, but this doesn't work because VersionTrackerQuerySet includes a call to distinct(), which resets the sticky flag.
