### PR TITLE
Fixup model loading

### DIFF
--- a/widgy/contrib/form_builder/models.py
+++ b/widgy/contrib/form_builder/models.py
@@ -935,7 +935,7 @@ class FormSubmission(models.Model):
 
     created_at = models.DateTimeField(auto_now_add=True)
     form_node = models.ForeignKey(Node, on_delete=models.PROTECT, related_name='form_submissions')
-    form_ident = models.CharField(max_length=Form._meta.get_field_by_name('ident')[0].max_length)
+    form_ident = models.CharField(max_length=Form._meta.get_field('ident', False).max_length)
 
     class FormSubmissionQuerySet(QuerySet):
         def get_formfield_labels(self):
@@ -1030,7 +1030,7 @@ class FormValue(models.Model):
     field_node = models.ForeignKey(Node, on_delete=models.SET_NULL, null=True)
     field_name = models.CharField(max_length=255)
     field_ident = models.CharField(
-        max_length=FormField._meta.get_field_by_name('ident')[0].max_length)
+        max_length=FormField._meta.get_field('ident', False).max_length)
 
     value = models.TextField()
 

--- a/widgy/db/fields.py
+++ b/widgy/db/fields.py
@@ -2,6 +2,7 @@ from django.db import models
 from django.db.models.fields.related import ReverseSingleRelatedObjectDescriptor
 from django.db.models.loading import get_app
 from django.contrib.contenttypes.models import ContentType
+from django.utils.functional import SimpleLazyObject
 
 # WidgyContentType has a patched get_for_models that doesn't ignore proxy
 # models
@@ -87,9 +88,10 @@ class WidgyField(models.ForeignKey):
 
     def formfield(self, **kwargs):
         from widgy.forms import WidgyFormField
+
         defaults = {
             'form_class': WidgyFormField,
-            'queryset': self.get_layout_contenttypes(self.root_choices),
+            'queryset': SimpleLazyObject(lambda: self.get_layout_contenttypes(self.root_choices)),
             'site': self.site,
         }
         defaults.update(kwargs)


### PR DESCRIPTION
- Using get_field_by_name loads the appcache, which is not allowed in a models module. Use get_field(False), which only looks at local fields and does not require populating the cache. This helps with #177.
- Do not call get_layout_contenttypes during model loading by making it lazy. get_layout_contenttypes does a ContentQuery, which requires that the django_content_type exists, which is not true during syncdb. This makes the DEBUG_TOOLBAR_PATCH_SETTINGS workaround in #244, #214, #235 unnecessary.

This paves the way for django 1.7 compatibility without the workarounds in #177. We also need to make scss_compile calls in page_builder.forms lazy (it uses staticfiles), but then we should be pretty close.
