### PR TITLE
Make Widgy's jQuery private

### DIFF
--- a/widgy/static/widgy/js/jquery-private.js
+++ b/widgy/static/widgy/js/jquery-private.js
@@ -1,0 +1,4 @@
+define(['jquery'], function (jq) {
+  // http://requirejs.org/docs/jquery.html#noconflictmap
+  return jq.noConflict( true );
+});

--- a/widgy/static/widgy/js/widgy.build.js
+++ b/widgy/static/widgy/js/widgy.build.js
@@ -18,4 +18,9 @@
             ],
         }
     ],
+    map: {
+      // http://requirejs.org/docs/jquery.html#noconflictmap
+      '*': { 'jquery': 'jquery-private' },
+      'jquery-private': { 'jquery': 'jquery' }
+    }
 })

--- a/widgy/templates/widgy/widgy_field.html
+++ b/widgy/templates/widgy/widgy_field.html
@@ -53,6 +53,11 @@ the admin center.
         }
       }
     },
+    map: {
+      // http://requirejs.org/docs/jquery.html#noconflictmap
+      '*': { 'jquery': 'jquery-private' },
+      'jquery-private': { 'jquery': 'jquery' }
+    },
     {% comment %}
     This looks like it might not work on paths with quotes in them, but
     the output of staticfiles.static [static.static DOES NOT, fyi] does


### PR DESCRIPTION
Widgy's jQuery was overwriting window.jQuery and window.$. This uses the recommendation from http://requirejs.org/docs/jquery.html#noconflictmap to prevent this.

This prevents bugs where other people loading jQuery on the page add plugins to it, and then Widgy's jQuery (without any plugins) overwrites theirs.
