### PR TITLE
ADD_PAGE_ORDER to demo.settings

### DIFF
--- a/demo/settings.py
+++ b/demo/settings.py
@@ -184,6 +184,10 @@ ADMIN_MENU_ORDER = [
     )),
 ]
 
+ADD_PAGE_ORDER = (
+    'widgy_mezzanine.WidgyPage',
+)
+
 URLCONF_INCLUDE_CHOICES = (
     ('demo.demo_url.urls', 'Demo url'),
 )


### PR DESCRIPTION
From @gavinwahl, comment here: https://github.com/fusionbox/django-widgy/pull/214#issuecomment-53352784
