### PR TITLE
Don't install mezzanine from source on Django 1.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,10 +37,6 @@ install: |
       pip install -q --use-mirrors psycopg2
     fi
     pip install --use-mirrors .
-    if echo "$DJANGO_PACKAGE" | grep -q '1.4.x'
-    then
-      pip install --use-mirrors -e git://github.com/stephenmcd/mezzanine@5dde99cd68b3ce5118b68#egg=mezzanine
-    fi
     pip freeze
   fi
 before_script:


### PR DESCRIPTION
The commit we were pinning to was released in Mezzanine 3.1.0.
