### PR TITLE
Removed django 1.5 from Travis - due to no security updates.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,10 @@ env:
   global:
     - SOUTH_TESTS_MIGRATE=1
   matrix:
-    - DATABASE_ENGINE=sqlite DJANGO_PACKAGE=https://github.com/django/django/archive/stable/1.5.x.zip
     - DATABASE_ENGINE=sqlite DJANGO_PACKAGE=https://github.com/django/django/archive/stable/1.6.x.zip
     - DATABASE_ENGINE=sqlite DJANGO_PACKAGE=https://github.com/django/django/archive/stable/1.4.x.zip
-    - DATABASE_ENGINE=postgres DJANGO_PACKAGE=https://github.com/django/django/archive/stable/1.5.x.zip
     - DATABASE_ENGINE=postgres DJANGO_PACKAGE=https://github.com/django/django/archive/stable/1.6.x.zip
     - DATABASE_ENGINE=postgres DJANGO_PACKAGE=https://github.com/django/django/archive/stable/1.4.x.zip
-    - DATABASE_ENGINE=mysql DJANGO_PACKAGE=https://github.com/django/django/archive/stable/1.5.x.zip
     - DATABASE_ENGINE=mysql DJANGO_PACKAGE=https://github.com/django/django/archive/stable/1.6.x.zip
     - DATABASE_ENGINE=mysql DJANGO_PACKAGE=https://github.com/django/django/archive/stable/1.4.x.zip
 matrix:

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 from setuptools import setup, find_packages
 import subprocess
 import os
+import sys
 
 __doc__ = """
 A CMS framework for Django built on a heterogenous tree editor.
@@ -19,7 +20,6 @@ install_requires = [
     'South',
     'django-pyscss',
     'six',
-    'markdown',
     'bleach',
     'django-compressor>=1.3',
     'django-extensions',
@@ -29,6 +29,12 @@ install_requires = [
     'phonenumbers>=5',
     'django-argonauts>=1.0.0',
 ]
+
+# Markdown stops support for Python 2.6 in version 2.5
+if sys.version_info < (2, 7):
+    install_requires.append('markdown<2.5')
+else:
+    install_requires.append('markdown')
 
 STAGE = 'alpha'
 


### PR DESCRIPTION
Not sure how stuck you all are on python 2.6, but markdown dropped support with release 2.5. Also, django is no longer providing security updates to 1.5.
