### PR TITLE
Only set related_name on ProxyGenericRelation when absolutely necessary

### DIFF
--- a/tests/modeltests/core_tests/models.py
+++ b/tests/modeltests/core_tests/models.py
@@ -256,3 +256,9 @@ class ReviewedVersionedPage(models.Model):
         root_choices=[Layout, AnotherLayout],
         to='review_queue.ReviewedVersionTracker',
     )
+
+
+# This just tests that it is possible to have two widgets of the same name in
+# different apps.
+class Button(Content):
+    pass

--- a/widgy/generic/__init__.py
+++ b/widgy/generic/__init__.py
@@ -35,6 +35,11 @@ else:
 
 
     class ProxyGenericRelation(generic.GenericRelation):
+        def __init__(self, *args, **kwargs):
+            # work around django #16920, #16913
+            kwargs.setdefault('related_name', '%(app_label)s_%(class)s_set')
+            super(ProxyGenericRelation, self).__init__(*args, **kwargs)
+
         def get_content_type(self):
             """
             Returns the content type associated with this field's model.

--- a/widgy/models/base.py
+++ b/widgy/models/base.py
@@ -399,8 +399,8 @@ class Content(models.Model):
     """
     _nodes = ProxyGenericRelation(Node,
                                   content_type_field='content_type',
-                                  object_id_field='content_id',
-                                  related_name='%(app_label)s_%(class)s_set')
+                                  object_id_field='content_id')
+
 
     # these preferences only affect the frontend interface and editing through
     # the API


### PR DESCRIPTION
To work around Django bugs in `<1.6`. Fixes #204 for Django `>= 1.6`.
