### PR TITLE
Fix prior commit to fix widgy owner for python 2.6

### DIFF
--- a/widgy/contrib/widgy_mezzanine/views.py
+++ b/widgy/contrib/widgy_mezzanine/views.py
@@ -148,7 +148,7 @@ class AdminViewMixin(object):
         return super(AdminViewMixin, self).dispatch(request, *args, **kwargs)
 
     def get_success_url(self):
-        return urlresolvers.reverse('admin:{}_{}_change'.format(
+        return urlresolvers.reverse('admin:{0}_{1}_change'.format(
             self.object._meta.app_label,
             self.object._meta.module_name), args=(self.object.pk,))
 


### PR DESCRIPTION
So changing to `'admin:{}_{}_change'.format(self.object._meta.app_label, self.object._meta.module_name)`, messed up the tests for python 2.6. 

The join method is uglier than this alternative:

`'admin:%s_%s_change' % ( obj._meta.app_label, obj._meta.module_name)`

however, is this method an old style of python?

@gavinwahl, how would you like this to look?
