### PR TITLE
Better labels for ContentTypeRadioInputs.

### DIFF
--- a/tests/modeltests/core_tests/models.py
+++ b/tests/modeltests/core_tests/models.py
@@ -266,3 +266,12 @@ class Button(Content):
 
 class WidgetWithHTMLHelpText(Content):
     name = models.CharField(max_length=255, help_text="Your<br>Name")
+
+
+class VerboseNameLayout(Content):
+    pass
+
+
+class VerboseNameLayoutChild(VerboseNameLayout):
+    class Meta:
+        verbose_name = 'Foobar'

--- a/tests/modeltests/core_tests/tests/forms.py
+++ b/tests/modeltests/core_tests/tests/forms.py
@@ -1,11 +1,16 @@
 from django.test import TestCase
 from django.test.client import RequestFactory
 from django import forms
+from django.contrib.contenttypes.models import ContentType
 
 from modeltests.core_tests.widgy_config import widgy_site
-from modeltests.core_tests.models import VariegatedFieldsWidget, WidgetWithHTMLHelpText
+from modeltests.core_tests.models import (
+    VariegatedFieldsWidget, VerboseNameLayout,
+    VerboseNameLayoutChild, WidgetWithHTMLHelpText,
+)
 
 from widgy.widgets import DateTimeWidget, DateWidget, TimeWidget
+from widgy.forms import WidgyFormField
 
 
 factory = RequestFactory()
@@ -32,3 +37,28 @@ class TestFieldAsDiv(TestCase):
         request = factory.get('/')
         rendered_form = widget.get_form_template(request)
         self.assertIn('Your<br>Name', rendered_form)
+
+
+class TestWidgyFormField(TestCase):
+    def test_content_type_radio_labels(self):
+        ct1 = ContentType.objects.get_for_model(VerboseNameLayout)
+        ct2 = ContentType.objects.get_for_model(VerboseNameLayoutChild)
+
+        # Sometimes the ContentType is created and stored in the database and
+        # then the developer changes the verbose_name of the model. We model
+        # that by retrieving the ContentType objects (which will put them in
+        # the database) and then changing the verbose_name.
+        VerboseNameLayoutChild._meta.verbose_name = 'barBaz'
+
+        field = WidgyFormField(
+            site=widgy_site,
+            queryset=ContentType.objects.filter(pk__in=[ct1.pk, ct2.pk]).order_by('pk'),
+        )
+
+        # owner can be None because WidgyFormField doesn't use it yet
+        field.conform_to_value(owner=None, value=None)
+
+        self.assertSequenceEqual(list(field.widget.choices), sorted([
+            (ct1.pk, 'Verbose name layout'),
+            (ct2.pk, 'BarBaz'),
+        ]))

--- a/widgy/forms.py
+++ b/widgy/forms.py
@@ -10,6 +10,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.core.urlresolvers import reverse
 from django.core.exceptions import ObjectDoesNotExist
 from django.conf import settings
+from django.template.defaultfilters import capfirst
 
 from widgy.utils import format_html
 from widgy.models import Node
@@ -149,6 +150,13 @@ class WidgyFormField(forms.ModelChoiceField):
                 raise
 
         return value
+
+    def label_from_instance(self, obj):
+        ModelClass = obj.model_class()
+        if ModelClass:
+            return capfirst(ModelClass._meta.verbose_name)
+        else:
+            return super(WidgyFormField, self).label_from_instance(obj)
 
 
 class VersionedWidgyWidget(WidgyWidget):


### PR DESCRIPTION
Every once in a while, I create a widget, the content type gets stored in the database and then I go to change the `verbose_name` of that widget, but the ContentType label is never updated in the database. This patch makes sure to use the current `verbose_name` of the model class. This should also enable the internationalization of of the ContentTypeRadioInputs, although I did not write a test for that.