### PR TITLE
Fixed styles in ckeditor to show justifications

### DIFF
--- a/widgy/contrib/page_builder/static/widgy/page_builder/html.scss
+++ b/widgy/contrib/page_builder/static/widgy/page_builder/html.scss
@@ -1,5 +1,5 @@
 .cke_editable, .htmlOutput {
-  @each $i in 'left' 'center' 'right' 'justify' {
+  @each $i in left center right justify {
     .align-#{$i} {
       text-align: $i;
     }


### PR DESCRIPTION
This is a fix for #279 Placing quotes around left, center, etc will add the quotes in the `text-align: 'left'` which is not the same as `text-align: left`