### PR TITLE
Don't unregister RichTextPage.

### DIFF
--- a/docs/tutorials/widgy-mezzanine-tutorial.rst
+++ b/docs/tutorials/widgy-mezzanine-tutorial.rst
@@ -208,25 +208,10 @@ then set ``URLCONF_INCLUDE_CHOICES`` to a list of allowed urlpatterns. For examp
         ('blog.urls', 'Blog'),
     )
 
-
-.. _django-pyscss: https://github.com/fusionbox/django-pyscss
-.. _pyScss: https://github.com/Kronuz/pyScss
-
 Adding Widgy to Mezzanine
 -------------------------
 If you are adding widgy to an existing mezzanine site, there are
 some additional considerations.
-
-If you have existing mezzanine RichTextPages, you will need
-to reregister it. Simply create an admin.py file in your directory
-and add this code::
-
-    from django.contrib import admin
-
-    from mezzanine.pages.admin import PageAdmin
-    from mezzanine.pages.models import RichTextPage
-
-    admin.site.register(RichTextPage, PageAdmin)
 
 If you have not done so already, add the root directory of your mezzanine
 install to INSTALLED_APPS.
@@ -239,3 +224,22 @@ it uses your root directory as your project file::
     WIDGY_MEZZANINE_SITE = 'myproject.demo.widgy_site.site'
     # Not:
     WIDGY_MEZZANINE_SITE = 'demo.widgy_site.site'
+
+
+Common Customizations
+---------------------
+
+If you only have :class:`WidgyPages
+<widgy.contrib.widgy_mezzanine.models.WidgyPage>`, you can choose to unregister
+the Mezzanine provided ``RichTextPage``.  Simply add this to an ``admin.py``
+file in your directory and add this code::
+
+    from django.contrib import admin
+
+    from mezzanine.pages.models import RichTextPage
+
+    admin.site.unregister(RichTextPage)
+
+
+.. _django-pyscss: https://github.com/fusionbox/django-pyscss
+.. _pyScss: https://github.com/Kronuz/pyScss

--- a/widgy/contrib/widgy_mezzanine/admin.py
+++ b/widgy/contrib/widgy_mezzanine/admin.py
@@ -256,11 +256,6 @@ class UndeletePage(WidgyPage):
         return super(UndeletePage, self).__init__(*args, **kwargs)
 
 
-# Remove built in Mezzanine models from the admin center
-from mezzanine.pages.models import RichTextPage
-
-admin.site.unregister(RichTextPage)
-
 admin.site.register(WidgyPage, WidgyPageAdmin)
 admin.site.register(UndeletePage, UndeletePageAdmin)
 


### PR DESCRIPTION
This was supposed to be removed in #197, but it somehow wasn't.
Hypothetically there are projects that use RichTextPages and WidgyPages
at the same time, it is not up to us to determine what those projects
can and cannot do.

@zmetcalf, what happened?