### PR TITLE
CSS support for adding fields to Image.

### DIFF
--- a/widgy/contrib/page_builder/static/widgy/page_builder/image.admin.scss
+++ b/widgy/contrib/page_builder/static/widgy/page_builder/image.admin.scss
@@ -1,6 +1,6 @@
 .widgy .node.image {
   .widget_editor {
-    .formField {
+    .formField.image {
       position: relative;
 
       label {

--- a/widgy/templates/widgy/field_as_div.html
+++ b/widgy/templates/widgy/field_as_div.html
@@ -1,7 +1,7 @@
 {% if field.is_hidden %}
   {{ field }}
 {% else %}
-<div class="{{ field.css_classes }} {{ field.html_name }} formField">
+<div class="{{ field.css_classes }} {{ field.html_name }}{% if field.html_name != field.name %} {{ field.name }}{% endif %} formField">
   {{ field.label_tag }}
   {{ field }}
   {{ field.errors }}


### PR DESCRIPTION
Previously the labels of every field were hidden. Now only the image
field doesn't have a label.

I was subclassing Image and setting my subclass' `css_classes` to `('page_builder', 'image')` for the icon, but I realized that my form labels were missing and I was like, WHAT?