### PR TITLE
Set model at runtime for ClonePageView and UnpublishView.

### DIFF
--- a/widgy/contrib/widgy_mezzanine/admin.py
+++ b/widgy/contrib/widgy_mezzanine/admin.py
@@ -89,8 +89,14 @@ class WidgyPageAdmin(PageAdmin):
     }
 
     def get_urls(self):
-        clone_view = ClonePageView.as_view(has_permission=self.has_add_permission)
-        unpublish_view = UnpublishView.as_view(has_change_permission=self.has_change_permission)
+        clone_view = ClonePageView.as_view(
+            model=self.model,
+            has_permission=self.has_add_permission,
+        )
+        unpublish_view = UnpublishView.as_view(
+            model=self.model,
+            has_change_permission=self.has_change_permission,
+        )
         return [
             url('^(.+)/clone/$', self.admin_site.admin_view(clone_view)),
             url('^(.+)/unpublish/$', self.admin_site.admin_view(unpublish_view)),

--- a/widgy/contrib/widgy_mezzanine/views.py
+++ b/widgy/contrib/widgy_mezzanine/views.py
@@ -136,8 +136,6 @@ class CloneForm(forms.ModelForm):
 
 
 class AdminViewMixin(object):
-    model = WidgyPage
-
     def get_object(self):
         obj = get_object_or_404(self.model, pk=unquote(self.args[0]))
         return obj


### PR DESCRIPTION
This allows us to reuse the WidgyPageAdmin for other WidgyPage-like
objects.

I'm doing craaaazy things over here!