### PR TITLE
Piper/remove hard requirement on mezzanine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,49 +1,42 @@
 language: python
 python:
   - "2.7"
-  - "2.6"
+cache:
+  directories:
+    - $HOME/.pip-cache/
 env:
   global:
     - SOUTH_TESTS_MIGRATE=1
   matrix:
-    - DATABASE_ENGINE=sqlite DJANGO_PACKAGE=https://github.com/django/django/archive/stable/1.6.x.zip
-    - DATABASE_ENGINE=sqlite DJANGO_PACKAGE=https://github.com/django/django/archive/stable/1.4.x.zip
-    - DATABASE_ENGINE=postgres DJANGO_PACKAGE=https://github.com/django/django/archive/stable/1.6.x.zip
-    - DATABASE_ENGINE=postgres DJANGO_PACKAGE=https://github.com/django/django/archive/stable/1.4.x.zip
-    - DATABASE_ENGINE=mysql DJANGO_PACKAGE=https://github.com/django/django/archive/stable/1.6.x.zip
-    - DATABASE_ENGINE=mysql DJANGO_PACKAGE=https://github.com/django/django/archive/stable/1.4.x.zip
-matrix:
-  include:
-    - python: "2.7"
-      env: JAVASCRIPT=1
-install: |
-  set -e
-  if [ -z "$JAVASCRIPT" ]
-  then
-    pip install --upgrade pip
-    pip install -q $DJANGO_PACKAGE --use-mirrors
-    pip install -q --use-mirrors mock
-    pip install -q --use-mirrors South
-
-    if [ "$DATABASE_ENGINE" = "mysql" ]
-    then
-      pip install -q --use-mirrors MySQL-python
-    fi
-
-    if [ "$DATABASE_ENGINE" = "postgres" ]
-    then
-      pip install -q --use-mirrors psycopg2
-    fi
-    pip install --use-mirrors -e .[all]
-    pip freeze
-  fi
+    - TOX_ENV=py26-dj14-sqlite
+    - TOX_ENV=py26-dj14-mysql
+    - TOX_ENV=py26-dj14-postgres
+    - TOX_ENV=py26-dj15-sqlite
+    - TOX_ENV=py26-dj15-mysql
+    - TOX_ENV=py26-dj15-postgres
+    - TOX_ENV=py27-dj14-sqlite
+    - TOX_ENV=py27-dj14-mysql
+    - TOX_ENV=py27-dj14-postgres
+    - TOX_ENV=py27-dj15-sqlite
+    - TOX_ENV=py27-dj15-mysql
+    - TOX_ENV=py27-dj15-postgres
+    - TOX_ENV=py27-dj16-sqlite
+    - TOX_ENV=py27-dj16-mysql
+    - TOX_ENV=py27-dj16-postgres
+    - TOX_ENV=javascript
+    - TOX_ENV=py26-dj14-contrib
+    - TOX_ENV=py26-dj15-contrib
+    - TOX_ENV=py26-dj16-contrib
+    - TOX_ENV=py27-dj14-contrib
+    - TOX_ENV=py27-dj15-contrib
+    - TOX_ENV=py27-dj16-contrib
+install:
+  - pip install --upgrade pip
+  - pip install tox
 before_script:
   - psql -c 'create database widgy;' -U postgres
   - mysql -e 'create database widgy;'
-script: |
-  if [ -z "$JAVASCRIPT" ]
-  then
-    make test-py
-  else
-    make test-js
-  fi
+script:
+  - tox -e $TOX_ENV
+after_script:
+  - cat .tox/$TOX_ENV/log/*.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,13 +23,25 @@ env:
     - TOX_ENV=py27-dj16-sqlite
     - TOX_ENV=py27-dj16-mysql
     - TOX_ENV=py27-dj16-postgres
+    - TOX_ENV=py26-dj14-contrib-sqlite
+    - TOX_ENV=py26-dj14-contrib-mysql
+    - TOX_ENV=py26-dj14-contrib-postgres
+    - TOX_ENV=py26-dj15-contrib-sqlite
+    - TOX_ENV=py26-dj15-contrib-mysql
+    - TOX_ENV=py26-dj15-contrib-postgres
+    - TOX_ENV=py26-dj16-contrib-sqlite
+    - TOX_ENV=py26-dj16-contrib-mysql
+    - TOX_ENV=py26-dj16-contrib-postgres
+    - TOX_ENV=py27-dj14-contrib-sqlite
+    - TOX_ENV=py27-dj14-contrib-mysql
+    - TOX_ENV=py27-dj14-contrib-postgres
+    - TOX_ENV=py27-dj15-contrib-sqlite
+    - TOX_ENV=py27-dj15-contrib-mysql
+    - TOX_ENV=py27-dj15-contrib-postgres
+    - TOX_ENV=py27-dj16-contrib-sqlite
+    - TOX_ENV=py27-dj16-contrib-mysql
+    - TOX_ENV=py27-dj16-contrib-postgres
     - TOX_ENV=javascript
-    - TOX_ENV=py26-dj14-contrib
-    - TOX_ENV=py26-dj15-contrib
-    - TOX_ENV=py26-dj16-contrib
-    - TOX_ENV=py27-dj14-contrib
-    - TOX_ENV=py27-dj15-contrib
-    - TOX_ENV=py27-dj16-contrib
 install:
   - pip install --upgrade pip
   - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ install: |
     pip install --upgrade pip
     pip install -q $DJANGO_PACKAGE --use-mirrors
     pip install -q --use-mirrors mock
+    pip install -q --use-mirrors South
 
     if [ "$DATABASE_ENGINE" = "mysql" ]
     then
@@ -33,7 +34,7 @@ install: |
     then
       pip install -q --use-mirrors psycopg2
     fi
-    pip install --use-mirrors .
+    pip install --use-mirrors -e .[page_builder,form_builder,widgy_mezzanine]
     pip freeze
   fi
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install: |
     then
       pip install -q --use-mirrors psycopg2
     fi
-    pip install --use-mirrors -e .[page_builder,form_builder,widgy_mezzanine]
+    pip install --use-mirrors -e .[all]
     pip freeze
   fi
 before_script:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ JS_FILES?=`find ./js_tests/tests -type f -name '*.js'`
 test: test-py test-js
 
 test-py:
-	cd tests && $(COVERAGE_COMMAND) ./runtests.py --settings=test_multidb --verbosity=2 $(TESTS)
+	cd tests && $(COVERAGE_COMMAND) ./runtests.py --verbosity=2 $(TESTS)
 
 coverage:
 	+make test-py COVERAGE_COMMAND='coverage run --source=widgy'

--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,7 @@ Running the Tests
 
 ::
 
+    pip install -r requirements-test.txt
     make test
 
 ``make test`` will run both the JavaScript and Python tests. To test one

--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,13 @@ Running the Tests
 ``make test`` will run both the JavaScript and Python tests. To test one
 or the other, use ``make test-js`` or ``make test-py``.
 
+::
+
+    $ tox
+
+``$ tox`` will run the full test suite across all of the supported versions of
+Django and Python.
+
 Coverage
 ********
 Once coverage_ is installed (``pip install coverage``), the Makefile

--- a/docs/contrib/form-builder/index.rst
+++ b/docs/contrib/form-builder/index.rst
@@ -12,6 +12,21 @@ your :django:setting:`INSTALLED_APPS`.
 
 .. currentmodule:: widgy.contrib.form_builder.models
 
+Installation
+------------
+
+Form builder depends on the following packages:
+
+* django-widgy[page_builder]
+* django-extensions
+* html2text
+* phonenumbers
+
+You can install them manually, or you can install them using the django-widgy
+package::
+
+    $ pip install django-widgy[page_builder,form_builder]
+
 Success Handlers
 ----------------
 

--- a/docs/contrib/page-builder/index.rst
+++ b/docs/contrib/page-builder/index.rst
@@ -5,6 +5,25 @@ Page Builder
 
 Page builder is a collection of widgets for the purpose of creating HTML pages.
 
+Installation
+------------
+
+Page builder depends on the following packages:
+
+* django-filer
+* markdown
+* bleach
+* sorl-thumbnail
+
+You can install them manually, or you can install them using the django-widgy
+package::
+
+    $ pip install django-widgy[page_builder]
+
+
+Widgets
+-------
+
 
 .. class:: DefaultLayout
 

--- a/docs/contrib/widgy-mezzanine/index.rst
+++ b/docs/contrib/widgy-mezzanine/index.rst
@@ -7,6 +7,16 @@ providing a subclass of Mezzanine's Page model called
 :class:`~widgy.contrib.widgy_mezzanine.models.WidgyPage` which delegates to
 Page Builder for all content.
 
+The dependencies for Widgy Mezzanine (Mezzanine and Widgy's Page Builder app)
+are not installed by default when you install widgy, you can install them
+yourself::
+
+    $ pip install Mezzanine django-widgy[page_builder]
+
+or you can install them using through the widgy package::
+
+    $ pip install django-widgy[page_builder,widgy_mezzanine]
+
 In order to use Widgy Mezzanine, you must provide ``WIDGY_MEZZANINE_SITE`` in
 your settings.  This is a fully-qualified import path to an instance of
 :class:`~widgy.site.WidgySite`.  You also need to install the URLs. ::

--- a/docs/tutorials/widgy-mezzanine-tutorial.rst
+++ b/docs/tutorials/widgy-mezzanine-tutorial.rst
@@ -10,7 +10,8 @@ This quickstart assumes you wish to use the following packages:
 
 Install the Widgy package::
 
-    pip install django-widgy
+    cd widgy
+    pip install -e .[all]
 
 Add Mezzanine apps to ``INSTALLED_APPS``::
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,4 @@
+mock
+env-excavator
+dj-database-url
+tox>=1.8.0

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ install_requires = [
     'mezzanine >= 3.1.10',
     'django-treebeard',
     'django-filer>=0.9.6',
-    'South',
     'django-pyscss',
     'six',
     'bleach',

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,8 @@ def read(fname):
 
 install_requires = [
     'django-treebeard',
+    # pyScss fixed until https://github.com/fusionbox/django-pyscss/pull/26 is fixed.
+    'pyScss==1.2.1',
     'django-pyscss',
     'six',
     'django-compressor>=1.3',
@@ -34,7 +36,9 @@ extras_require = {
         'mezzanine>=3.1.10',
     ],
     'page_builder': [
-        'django-filer>=0.9.6',
+        # until https://github.com/stefanfoulis/django-filer/pull/480 is merged.
+        #'django-filer>0.9.8',
+        'django-filer==0.9.5',
         'markdown',
         'bleach',
         'sorl-thumbnail>=11.12',

--- a/setup.py
+++ b/setup.py
@@ -14,18 +14,11 @@ def read(fname):
 
 
 install_requires = [
-    'mezzanine >= 3.1.10',
     'django-treebeard',
-    'django-filer>=0.9.6',
     'django-pyscss',
     'six',
-    'bleach',
     'django-compressor>=1.3',
-    'django-extensions',
     'beautifulsoup4',
-    'sorl-thumbnail>=11.12',
-    'html2text>=3.200.3',
-    'phonenumbers>=5',
     'django-argonauts>=1.0.0',
 ]
 
@@ -34,6 +27,24 @@ if sys.version_info < (2, 7):
     install_requires.append('markdown<2.5')
 else:
     install_requires.append('markdown')
+
+
+extras_require = {
+    'widgy_mezzanine': [
+        'mezzanine>=3.1.10',
+    ],
+    'page_builder': [
+        'django-filer>=0.9.6',
+        'markdown',
+        'bleach',
+        'sorl-thumbnail>=11.12',
+    ],
+    'form_builder': [
+        'django-extensions',
+        'html2text>=3.200.3',
+        'phonenumbers>=5',
+    ],
+}
 
 STAGE = 'alpha'
 
@@ -60,6 +71,7 @@ setup(
     url='http://docs.wid.gy/',
     packages=[package for package in find_packages() if package.startswith('widgy')],
     install_requires=install_requires,
+    extras_require=extras_require,
     zip_safe=False,
     include_package_data=True,
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -36,9 +36,7 @@ extras_require = {
         'mezzanine>=3.1.10',
     ],
     'page_builder': [
-        # until https://github.com/stefanfoulis/django-filer/pull/480 is merged.
-        #'django-filer>0.9.8',
-        'django-filer==0.9.5',
+        'django-filer>=0.9.9',
         'markdown',
         'bleach',
         'sorl-thumbnail>=11.12',

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,8 @@ extras_require = {
     ],
 }
 
+extras_require['all'] = set(j for i in extras_require.values() for j in i)
+
 STAGE = 'alpha'
 
 version = (0, 4, 0, STAGE)

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,6 @@ def read(fname):
 
 install_requires = [
     'django-treebeard',
-    # pyScss fixed until https://github.com/fusionbox/django-pyscss/pull/26 is fixed.
-    'pyScss==1.2.1',
     'django-pyscss',
     'six',
     'django-compressor>=1.3',

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -3,197 +3,71 @@ import os
 import shutil
 import sys
 import tempfile
-from operator import itemgetter
 
-from widgy import contrib
 try:
     import six
 except ImportError:
     from django.utils import six
 
 
-def upath(path):
-    """
-    Always return a unicode path.
-    """
-    if not six.PY3:
-        fs_encoding = sys.getfilesystemencoding() or sys.getdefaultencoding()
-        return path.decode(fs_encoding)
-    return path
-
-CONTRIB_DIR_NAME = 'widgy.contrib'
-MODEL_TESTS_DIR_NAME = 'modeltests'
-REGRESSION_TESTS_DIR_NAME = 'regressiontests'
-
-TEST_TEMPLATE_DIR = 'templates'
-
-RUNTESTS_DIR = os.path.dirname(upath(__file__))
-CONTRIB_DIR = os.path.dirname(upath(contrib.__file__))
-MODEL_TEST_DIR = os.path.join(RUNTESTS_DIR, MODEL_TESTS_DIR_NAME)
-REGRESSION_TEST_DIR = os.path.join(RUNTESTS_DIR, REGRESSION_TESTS_DIR_NAME)
 TEMP_DIR = tempfile.mkdtemp(prefix='django_')
 os.environ['DJANGO_TEST_TEMP_DIR'] = TEMP_DIR
 
-REGRESSION_SUBDIRS_TO_SKIP = []
 
-ALWAYS_INSTALLED_APPS = [
-    'django.contrib.contenttypes',
-    'django.contrib.auth',
-    'django.contrib.sites',
-    'django.contrib.sessions',
-    'django.contrib.messages',
-    'django.contrib.admin',
-    'django.contrib.staticfiles',
-    "mezzanine.boot",
-    "mezzanine.conf",
-    "mezzanine.core",
-    "mezzanine.generic",
-    "mezzanine.pages",
-    "mezzanine.forms",
-    'django.contrib.comments',
-    'filebrowser_safe',
-    'grappelli_safe',
-    # blog is affected by https://code.djangoproject.com/ticket/12728
-    # "mezzanine.blog",
-    "widgy",
-    "treebeard",
-    "compressor",
-    "argonauts",
-    "filer",
-    "south",
-]
-
-def get_test_modules():
-    modules = []
-    for loc, dirpath in (
-        (MODEL_TESTS_DIR_NAME, MODEL_TEST_DIR),
-        (REGRESSION_TESTS_DIR_NAME, REGRESSION_TEST_DIR),
-        (CONTRIB_DIR_NAME, CONTRIB_DIR)):
-        for f in os.listdir(dirpath):
-            if (f.startswith('__init__') or
-                f.startswith('.') or
-                # Python 3 byte code dirs (PEP 3147)
-                f == '__pycache__' or
-                f.startswith('sql') or
-                os.path.basename(f) in REGRESSION_SUBDIRS_TO_SKIP):
-                continue
-            files = os.listdir(os.path.join(dirpath, f))
-            # skip directories with no python files
-            for file in files:
-                if file.endswith('.py'):
-                    modules.append((loc, f))
-                    break
-    return modules
-
-def setup(verbosity, test_labels):
+def get_contrib_test_modules():
     from django.conf import settings
-    state = {
-        'INSTALLED_APPS': settings.INSTALLED_APPS,
-        'ROOT_URLCONF': getattr(settings, "ROOT_URLCONF", ""),
-        'TEMPLATE_DIRS': settings.TEMPLATE_DIRS,
-        'USE_I18N': settings.USE_I18N,
-        'LOGIN_URL': settings.LOGIN_URL,
-        'LANGUAGE_CODE': settings.LANGUAGE_CODE,
-        'MIDDLEWARE_CLASSES': settings.MIDDLEWARE_CLASSES,
-        'STATIC_URL': settings.STATIC_URL,
-        'STATIC_ROOT': settings.STATIC_ROOT,
-    }
-
-    # Redirect some settings for the duration of these tests.
-    settings.INSTALLED_APPS = ALWAYS_INSTALLED_APPS
-    settings.ROOT_URLCONF = 'urls'
-    settings.STATIC_URL = '/static/'
-    settings.STATIC_ROOT = os.path.join(TEMP_DIR, 'static')
-    settings.MEDIA_URL = '/media/'
-    settings.MEDIA_ROOT = os.path.join(TEMP_DIR, 'media')
-    settings.TEMPLATE_DIRS = (os.path.join(RUNTESTS_DIR, TEST_TEMPLATE_DIR),)
-    settings.USE_I18N = True
-    settings.LANGUAGE_CODE = 'en'
-    settings.LOGIN_URL = 'django.contrib.auth.views.login'
-    settings.MIDDLEWARE_CLASSES = (
-        'django.contrib.sessions.middleware.SessionMiddleware',
-        'django.contrib.auth.middleware.AuthenticationMiddleware',
-        'django.contrib.messages.middleware.MessageMiddleware',
-        'django.middleware.common.CommonMiddleware',
-    )
-    settings.SITE_ID = 1
-    settings.WIDGY_MEZZANINE_SITE = 'modeltests.core_tests.widgy_config.widgy_site'
-    settings.DAISYDIFF_JAR_PATH = os.path.join(os.path.dirname(__file__),
-                                               '..', 'bin', 'daisydiff', 'daisydiff.jar')
+    return tuple((
+        module.split('.')[-1] for module in settings.INSTALLED_APPS if module.startswith('widgy.contrib')
+    ))
 
 
-    # mezzanine junk
-    settings.PACKAGE_NAME_FILEBROWSER = "filebrowser_safe"
-
-    # mezzanine sets this to a tuple, but we need ot to be a list
-    settings.INSTALLED_APPS = list(settings.INSTALLED_APPS)
-
-    # Load all the ALWAYS_INSTALLED_APPS.
-    # (This import statement is intentionally delayed until after we
-    # access settings because of the USE_I18N dependency.)
-    from django.db.models.loading import get_apps, load_app
-    get_apps()
-
-    # Load all the test model apps.
-    test_labels_set = set([label.split('.')[0] for label in test_labels])
-    test_modules = get_test_modules()
-
-    # easy_thumbnails changes how it does migrations
-    import easy_thumbnails
-
-    if easy_thumbnails.VERSION >= 2:
-        SOUTH_MIGRATION_MODULES = {
-            'easy_thumbnails': 'easy_thumbnails.south_migrations',
-        }
-
-    for module_dir, module_name in test_modules:
-        module_label = '.'.join([module_dir, module_name])
-        # if the module was named on the command line, or
-        # no modules were named (i.e., run all), import
-        # this module and add it to the list to test.
-        if not test_labels or module_name in test_labels_set:
-            if verbosity >= 2:
-                print("Importing application %s" % module_name)
-            mod = load_app(module_label)
-            if mod:
-                if module_label not in settings.INSTALLED_APPS:
-                    settings.INSTALLED_APPS.append(module_label)
-
-    return state
-
-def teardown(state):
-    from django.conf import settings
+def teardown():
     # Removing the temporary TEMP_DIR. Ensure we pass in unicode
     # so that it will successfully remove temp trees containing
     # non-ASCII filenames on Windows. (We're assuming the temp dir
     # name itself does not contain non-ASCII characters.)
     shutil.rmtree(six.text_type(TEMP_DIR))
-    # Restore the old settings.
-    for key, value in state.items():
-        setattr(settings, key, value)
+
 
 def django_tests(verbosity, interactive, failfast, test_labels):
     from django.conf import settings
-
-    state = setup(verbosity, test_labels)
-    extra_tests = []
 
     # must be imported after settings are set up
     from south.management.commands import patch_for_test_db_setup
     patch_for_test_db_setup()
 
-    # Run the test suite, including the extra validation tests.
     from django.test.utils import get_runner
-    if not hasattr(settings, 'TEST_RUNNER'):
-        settings.TEST_RUNNER = 'django.test.simple.DjangoTestSuiteRunner'
     TestRunner = get_runner(settings)
 
-    test_runner = TestRunner(verbosity=verbosity, interactive=interactive,
-        failfast=failfast)
-    failures = test_runner.run_tests(test_labels, extra_tests=extra_tests)
+    if not test_labels:
+        # apps to test
+        test_labels = CORE_TEST_MODULES + get_contrib_test_modules()
 
-    teardown(state)
+    test_runner = TestRunner(verbosity=verbosity, interactive=interactive,
+                             failfast=failfast)
+    failures = test_runner.run_tests(test_labels)
+
+    teardown()
     return failures
+
+
+CONTRIB_TEST_MODULES = (
+    'form_builder',
+    'page_builder',
+    'review_queue',
+    'urlconf_include',
+    'widgy_i18n',
+    'widgy_mezzanine',
+)
+
+
+CORE_TEST_MODULES = (
+    'core_tests',
+    'proxy_gfk',
+    'utilstests',
+    'widgy',
+)
+
 
 if __name__ == "__main__":
     from optparse import OptionParser
@@ -222,14 +96,10 @@ if __name__ == "__main__":
              'LiveServerTestCase) is expected to run from. The default value '
              'is localhost:8081.'),
     options, args = parser.parse_args()
-    if not args:
-        # apps to test
-        args = map(itemgetter(1), get_test_modules()) + ['widgy']
     if options.settings:
         os.environ['DJANGO_SETTINGS_MODULE'] = options.settings
     elif "DJANGO_SETTINGS_MODULE" not in os.environ:
-        parser.error("DJANGO_SETTINGS_MODULE is not set in the environment. "
-                      "Set it or use --settings.")
+        options.settions = os.environ['DJANGO_SETTINGS_MODULE'] = 'settings'
     else:
         options.settings = os.environ['DJANGO_SETTINGS_MODULE']
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,0 +1,118 @@
+import os
+import sys
+import excavator
+import dj_database_url
+
+try:
+    import six
+except ImportError:
+    from django.utils import six
+
+DATABASES = {'default': dj_database_url.config(default='sqlite:///test_db.sqlite3')}
+
+SECRET_KEY = "widgy_tests_secret_key"
+# To speed up tests under SQLite we use the MD5 hasher as the default one.
+# This should not be needed under other databases, as the relative speedup
+# is only marginal there.
+PASSWORD_HASHERS = (
+    'django.contrib.auth.hashers.MD5PasswordHasher',
+    'django.contrib.auth.hashers.SHA1PasswordHasher',
+)
+
+INSTALLED_APPS = [
+    'django.contrib.contenttypes',
+    'django.contrib.auth',
+    'django.contrib.sites',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.admin',
+    'django.contrib.staticfiles',
+    "widgy",
+    "treebeard",
+    "compressor",
+    "argonauts",
+    "south",
+    # tests modules
+    "modeltests.core_tests",
+    "modeltests.proxy_gfk",
+    "regressiontests.utilstests",
+    # tests/modeltests/core_tests/models::ReviewedVersionedPage has an fk to
+    # `review_queue.ReviewedVersionTracker`.  Until that test is moved into a
+    # contrib test suite, that app neeeds to be installed.
+    "widgy.contrib.review_queue",
+]
+
+SOUTH_TESTS_MIGRATE = excavator.env_bool('SOUTH_TESTS_MIGRATE', default=False)
+
+try:
+    import easy_thumbnails
+except ImportError:
+    pass
+else:
+    if easy_thumbnails.VERSION >= 2:
+        SOUTH_MIGRATION_MODULES = {
+            'easy_thumbnails': 'easy_thumbnails.south_migrations',
+        }
+
+URLCONF_INCLUDE_CHOICES = tuple()
+TEST_RUNNER = 'django.test.simple.DjangoTestSuiteRunner'
+
+MESSAGE_STORAGE = 'django.contrib.messages.storage.session.SessionStorage'
+
+TESTING = False
+SITE_ID = 1
+
+
+def upath(path):
+    """
+    Always return a unicode path.
+    """
+    if not six.PY3:
+        fs_encoding = sys.getfilesystemencoding() or sys.getdefaultencoding()
+        return path.decode(fs_encoding)
+    return path
+
+RUNTESTS_DIR = os.path.dirname(upath(__file__))
+TEST_TEMPLATE_DIR = 'templates'
+
+TEMP_DIR = excavator.env_string('DJANGO_TEST_TEMP_DIR', required=True)
+
+ROOT_URLCONF = 'urls'
+STATIC_URL = '/static/'
+STATIC_ROOT = os.path.join(TEMP_DIR, 'static')
+MEDIA_URL = '/media/'
+MEDIA_ROOT = os.path.join(TEMP_DIR, 'media')
+TEMPLATE_DIRS = (os.path.join(RUNTESTS_DIR, TEST_TEMPLATE_DIR),)
+USE_I18N = True
+LANGUAGE_CODE = 'en'
+LOGIN_URL = 'django.contrib.auth.views.login'
+
+STATICFILES_FINDERS = (
+    'django.contrib.staticfiles.finders.FileSystemFinder',
+    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
+    'compressor.finders.CompressorFinder',
+)
+
+MIDDLEWARE_CLASSES = (
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.common.CommonMiddleware',
+)
+
+TEMPLATE_CONTEXT_PROCESSORS = (
+    "django.contrib.auth.context_processors.auth",
+    "django.contrib.messages.context_processors.messages",
+    "django.core.context_processors.debug",
+    "django.core.context_processors.i18n",
+    "django.core.context_processors.static",
+    "django.core.context_processors.media",
+    "django.core.context_processors.request",
+)
+
+# Widgy Settings
+WIDGY_MEZZANINE_SITE = 'modeltests.core_tests.widgy_config.widgy_site'
+
+DAISYDIFF_JAR_PATH = os.path.join(
+    os.path.dirname(__file__), '..', 'bin', 'daisydiff', 'daisydiff.jar',
+)

--- a/tests/settings_contrib.py
+++ b/tests/settings_contrib.py
@@ -1,0 +1,17 @@
+import excavator
+
+from settings import *
+
+
+PACKAGE_NAME_FILEBROWSER = "filebrowser_safe"
+PACKAGE_NAME_GRAPPELLI = "grappelli_safe"
+GRAPPELLI_INSTALLED = True
+
+#INSTALLED_APPS += excavator.env_list('EXTRA_INSTALLED_APPS', required=True)
+INSTALLED_APPS += excavator.env_list('EXTRA_INSTALLED_APPS', required=True)
+
+
+TEMPLATE_CONTEXT_PROCESSORS += (
+    "mezzanine.conf.context_processors.settings",
+    "mezzanine.pages.context_processors.page",
+)

--- a/tests/test_sqlite.py
+++ b/tests/test_sqlite.py
@@ -21,7 +21,7 @@ DATABASES = {
 }
 
 SECRET_KEY = "widgy_tests_secret_key"
-# To speed up tests under SQLite we use the MD5 hasher as the default one. 
+# To speed up tests under SQLite we use the MD5 hasher as the default one.
 # This should not be needed under other databases, as the relative speedup
 # is only marginal there.
 PASSWORD_HASHERS = (
@@ -56,6 +56,4 @@ TEMPLATE_CONTEXT_PROCESSORS = (
     "django.core.context_processors.static",
     "django.core.context_processors.media",
     "django.core.context_processors.request",
-    "mezzanine.conf.context_processors.settings",
-    "mezzanine.pages.context_processors.page",
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,111 +1,45 @@
 [tox]
-envlist=py27-dj14,py27-dj15,py26-dj14,py26-dj15,py27-dj16
+envlist=
+    # core python/django/database
+    py26-dj{14,15}-{sqlite,mysql,postgres},
+    py27-dj{14,15,16}-{sqlite,mysql,postgres},
+    # contrib
+    py{26,27}-dj{14,15,16}-contrib,
+    # javascript
+    javascript
 
 [testenv]
-commands=/usr/bin/env make test
+basepython=
+  py26: python2.6
+  py27: python2.7
+commands=
+  contrib: pip install -e .[page_builder,widgy_mezzanine,form_builder] --log-file {envdir}/pip-extras-require-log.log
+  /usr/bin/env
+  make test-py
+setenv=
+  sqlite: DATABASE_URL=sqlite:///test_db.sqlite3
+  postgres: DATABASE_URL=postgres://postgres:@127.0.0.1:5432/widgy
+  mysql: DATABASE_URL=mysql://root:@127.0.0.1:3306/widgy
+  contrib: DJANGO_SETTINGS_MODULE=settings_contrib
+  contrib: EXTRA_INSTALLED_APPS=mezzanine.boot,mezzanine.conf,mezzanine.core,mezzanine.generic,mezzanine.pages,mezzanine.forms,django.contrib.comments,filebrowser_safe,grappelli_safe,filer,widgy.contrib.widgy_mezzanine,widgy.contrib.form_builder,widgy.contrib.page_builder,widgy.contrib.review_queue,widgy.contrib.urlconf_include,widgy.contrib.widgy_i18n
+deps=
+  dj14,dj15,dj16: South>=1.0.2
+  dj14: Django>=1.4,<1.5
+  dj15: Django>=1.5,<1.6
+  dj16: Django>=1.6,<1.7
+  mysql: MySQL-python
+  postgres: psycopg2
+  mock
+  env-excavator
+  dj-database-url
+whitelist_externals=
+  env
+  make
 
-[testenv:py27-dj14]
+[testenv:javascript]
 basepython=python2.7
-deps =
-  Django==1.4
-
-[testenv:py27-dj15]
-basepython=python2.7
-deps =
-  https://www.djangoproject.com/download/1.5c1/tarball/
-
-[testenv:py26-dj14]
-basepython=python2.6
-deps =
-  Django==1.4
-
-[testenv:py26-dj15]
-basepython=python2.6
-deps =
-  https://www.djangoproject.com/download/1.5c1/tarball/
-
-[testenv:py27-dj16]
-basepython=python2.7
-deps =
-  --editable=git+https://github.com/django/django@master#egg=django
-
-[testenv:py26-dj15-mysql]
-basepython=python2.6
-deps =
-  https://www.djangoproject.com/download/1.5c1/tarball/
-  MySQL-python==1.2.3
-setenv =
-  DATABASE_ENGINE=mysql
-
-[testenv:py27-dj15-mysql]
-basepython=python2.7
-deps =
-  https://www.djangoproject.com/download/1.5c1/tarball/
-  MySQL-python==1.2.3
-setenv =
-  DATABASE_ENGINE=mysql
-
-[testenv:py27-dj14-mysql]
-basepython=python2.7
-deps =
-  Django==1.4
-  MySQL-python==1.2.3
-setenv =
-  DATABASE_ENGINE=mysql
-
-[testenv:py27-dj16-mysql]
-basepython=python2.7
-deps =
-  --editable=git+https://github.com/django/django@master#egg=django
-  MySQL-python==1.2.3
-setenv =
-  DATABASE_ENGINE=mysql
-
-[testenv:py26-dj14-mysql]
-basepython=python2.6
-deps =
-  Django==1.4
-  MySQL-python==1.2.3
-setenv =
-  DATABASE_ENGINE=mysql
-
-
-[testenv:py26-dj15-postgres]
-basepython=python2.6
-deps =
-  https://www.djangoproject.com/download/1.5c1/tarball/
-  psycopg2
-setenv =
-  DATABASE_ENGINE=postgres
-
-[testenv:py27-dj15-postgres]
-basepython=python2.7
-deps =
-  https://www.djangoproject.com/download/1.5c1/tarball/
-  psycopg2
-setenv =
-  DATABASE_ENGINE=postgres
-
-[testenv:py27-dj14-postgres]
-basepython=python2.7
-deps =
-  Django==1.4
-  psycopg2
-setenv =
-  DATABASE_ENGINE=postgres
-
-[testenv:py26-dj14-postgres]
-basepython=python2.6
-deps =
-  Django==1.4
-  psycopg2
-setenv =
-  DATABASE_ENGINE=postgres
-
-[testenv:py27-dj16-postgres]
-basepython=python2.7
-deps =
-  --editable=git+https://github.com/django/django@master#egg=django
-  psycopg2
-setenv =
-  DATABASE_ENGINE=postgres
+commands=
+  /usr/bin/env
+  make test-js
+skipsdist=true
+deps=

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist=
     py26-dj{14,15}-{sqlite,mysql,postgres},
     py27-dj{14,15,16}-{sqlite,mysql,postgres},
     # contrib
-    py{26,27}-dj{14,15,16}-contrib,
+    py{26,27}-dj{14,15,16}-contrib-{sqlite,mysql,postgres},
     # javascript
     javascript
 

--- a/tox.ini
+++ b/tox.ini
@@ -30,9 +30,8 @@ deps=
   dj16: Django>=1.6,<1.7
   mysql: MySQL-python
   postgres: psycopg2
-  mock
-  env-excavator
-  dj-database-url
+  # Intentionaly no space between -r{toxinidir} because tox falls over if there is a space.
+  -r{toxinidir}/requirements-test.txt
 whitelist_externals=
   env
   make

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ setenv=
   contrib: EXTRA_INSTALLED_APPS=mezzanine.boot,mezzanine.conf,mezzanine.core,mezzanine.generic,mezzanine.pages,mezzanine.forms,django.contrib.comments,filebrowser_safe,grappelli_safe,filer,widgy.contrib.widgy_mezzanine,widgy.contrib.form_builder,widgy.contrib.page_builder,widgy.contrib.review_queue,widgy.contrib.urlconf_include,widgy.contrib.widgy_i18n
 deps=
   dj14,dj15,dj16: South>=1.0.2
+  dj14,dj15: django-treebeard<3.0
   dj14: Django>=1.4,<1.5
   dj15: Django>=1.5,<1.6
   dj16: Django>=1.6,<1.7

--- a/widgy/contrib/page_builder/db/fields.py
+++ b/widgy/contrib/page_builder/db/fields.py
@@ -12,11 +12,14 @@ from filer.models.filemodels import File
 
 from widgy.contrib.page_builder.forms import MarkdownField as MarkdownFormField, MarkdownWidget
 
-from south.modelsinspector import add_introspection_rules
-
-add_introspection_rules([], ["^widgy\.contrib\.page_builder\.db\.fields\.MarkdownField"])
-add_introspection_rules([], ["^widgy\.contrib\.page_builder\.db\.fields\.VideoField"])
-add_introspection_rules([], ["^widgy\.contrib\.page_builder\.db\.fields\.ImageField"])
+try:
+    from south.modelsinspector import add_introspection_rules
+except ImportError:  # South not installed
+    pass
+else:
+    add_introspection_rules([], ["^widgy\.contrib\.page_builder\.db\.fields\.MarkdownField"])
+    add_introspection_rules([], ["^widgy\.contrib\.page_builder\.db\.fields\.VideoField"])
+    add_introspection_rules([], ["^widgy\.contrib\.page_builder\.db\.fields\.ImageField"])
 
 
 class MarkdownField(models.TextField):

--- a/widgy/contrib/widgy_mezzanine/tests.py
+++ b/widgy/contrib/widgy_mezzanine/tests.py
@@ -244,6 +244,7 @@ class PageSetup(object):
 class AdminView(PageSetup):
     def as_view(self, **kwargs):
         kwargs.setdefault('has_permission', lambda req: True)
+        kwargs.setdefault('model', WidgyPage)
         return self.view_cls.as_view(**kwargs)
 
     def test_permissions(self):
@@ -257,7 +258,7 @@ class TestClonePage(AdminView, TestCase):
     view_cls = ClonePageView
 
     def test_get(self):
-        view = self.as_view()
+        view = self.as_view(model=WidgyPage)
 
         resp = view(self.factory.get('/'), str(self.page.pk))
         self.assertEqual(resp.status_code, 200)
@@ -265,7 +266,7 @@ class TestClonePage(AdminView, TestCase):
         self.assertNotIn(self.page.slug, resp.rendered_content)
 
     def test_post(self):
-        view = self.as_view()
+        view = self.as_view(model=WidgyPage)
         with mock.patch('django.contrib.messages.success') as success_mock:
             req = self.factory.post('/', {'title': 'new title'})
 
@@ -290,7 +291,7 @@ class TestUnpublish(AdminView, TestCase):
     def test_unpublish(self):
         self.assertEqual(self.page.status, CONTENT_STATUS_PUBLISHED)
 
-        view = self.as_view()
+        view = self.as_view(model=WidgyPage)
         resp = view(self.factory.get('/'), str(self.page.pk))
         self.assertEqual(resp.status_code, 200)
         self.assertIn(self.page.title, resp.rendered_content)

--- a/widgy/db/fields.py
+++ b/widgy/db/fields.py
@@ -9,10 +9,13 @@ from django.utils.functional import SimpleLazyObject
 from widgy.generic.models import ContentType as WidgyContentType
 from widgy.utils import fancy_import, update_context
 
-from south.modelsinspector import add_introspection_rules
-
-add_introspection_rules([], ["^widgy\.db.fields\.WidgyField"])
-add_introspection_rules([], ["^widgy\.db.fields\.VersionedWidgyField"])
+try:
+    from south.modelsinspector import add_introspection_rules
+except ImportError:  # South not installed
+    pass
+else:
+    add_introspection_rules([], ["^widgy\.db.fields\.WidgyField"])
+    add_introspection_rules([], ["^widgy\.db.fields\.VersionedWidgyField"])
 
 
 def get_site(site):

--- a/widgy/generic/__init__.py
+++ b/widgy/generic/__init__.py
@@ -3,11 +3,15 @@ from django.contrib.contenttypes import generic
 from django.db import DEFAULT_DB_ALIAS, connection
 from widgy.generic.models import ContentType
 
-from south.modelsinspector import add_ignored_fields
+try:
+    from south.modelsinspector import add_ignored_fields
+except ImportError:  # South not installed.
+    pass
+else:
+    add_ignored_fields(["^widgy\.generic\.ProxyGenericRelation",
+                        "^widgy\.generic\.ProxyGenericForeignKey",
+                        "^widgy\.generic\.WidgyGenericForeignKey"])
 
-add_ignored_fields(["^widgy\.generic\.ProxyGenericRelation",
-                    "^widgy\.generic\.ProxyGenericForeignKey",
-                    "^widgy\.generic\.WidgyGenericForeignKey"])
 
 if django.VERSION >= (1, 6):
     class ProxyGenericForeignKey(generic.GenericForeignKey):

--- a/widgy/templatetags/widgy_tags.py
+++ b/widgy/templatetags/widgy_tags.py
@@ -2,8 +2,6 @@ from django import template
 from django.conf import settings
 from django.utils.safestring import mark_safe
 
-import markdown
-
 from widgy.utils import fancy_import, update_context
 
 register = template.Library()
@@ -40,6 +38,7 @@ def js_files(site):
 
 @register.filter(name='markdown')
 def mdown(value):
+    import markdown
     value = markdown.markdown(
         value,
         extensions=['sane_lists'],


### PR DESCRIPTION
### What is the problem / feature ?

Currently, the dependencies of the `contrib` apps are all set as hard dependencies in `setup.py`.  This is not ideal for use cases that do not involve the contrib applications. (like not using mezzanine)

### How did it get fixed / implemented ?

This branch is based on https://github.com/fusionbox/django-widgy/pull/221

- Rework the test matrix to test the core application and the contrib applications separately.
- Implemented one matrix of runs for
    - databases: `mysql, postgres, sqlite`
    - python: `python2.6, python2.7`
    - django: `1.4.x, 1.5.x, 1.6.x`
- Implement another matrix of runs using
    - database: `sqlite`
    - python: `python2.7, python2.7`
    - django: `1.4.x, 1.5.x, 1.6.x`

### How can someone test / see it ?

Mostly behind the scenes stuff.  Take a look at the travis test runs.

*Here is a cute animal picture for your troubles...*


![baby turtle perches on top of succulent strawberry twice his size on fruit farm 2](https://cloud.githubusercontent.com/assets/824194/5686482/64d7d524-9800-11e4-8981-cf3af964e66b.jpg)
