### PR TITLE
Fix r.js optimization errors with daisydiff

### DIFF
--- a/widgy/static/daisydiff/css/diff.css
+++ b/widgy/static/daisydiff/css/diff.css
@@ -39,13 +39,11 @@ span.diff-html-removed {
 }
 
 span.diff-html-changed {
-  /* background: url(/static/daisydiff/images/diffunderline.gif) bottom repeat-x; */
   *background-color: #c6c6fd; /* light blue */
   cursor: pointer;
 }
 
 span.diff-html-conflict {
-/*  background: url(../images/diffunderline.gif) bottom repeat-x; */
   background-color: #f781be; /* light rose */
 }
 


### PR DESCRIPTION
## Problem

I was trying to run the r.js optimizer (with django-require) on my own code, but it threw the following error:

```
Post-processing 'daisydiff/css/diff.css' failed!

Traceback (most recent call last):
  File "manage.py", line 9, in <module>
    execute_from_command_line(sys.argv)
  File "/var/python-environments/XXXX/lib/python2.6/site-packages/django/core/management/__init__.py", line 399, in execute_from_command_line
    utility.execute()
  File "/var/python-environments/XXXX/lib/python2.6/site-packages/django/core/management/__init__.py", line 392, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/var/python-environments/XXXX/lib/python2.6/site-packages/django/core/management/base.py", line 242, in run_from_argv
    self.execute(*args, **options.__dict__)
  File "/var/python-environments/XXXX/lib/python2.6/site-packages/django/core/management/base.py", line 285, in execute
    output = self.handle(*args, **options)
  File "/var/python-environments/XXXX/lib/python2.6/site-packages/django/core/management/base.py", line 415, in handle
    return self.handle_noargs(**options)
  File "/var/python-environments/XXXX/lib/python2.6/site-packages/django/contrib/staticfiles/management/commands/collectstatic.py", line 173, in handle_noargs
    collected = self.collect()
  File "/var/python-environments/XXXX/lib/python2.6/site-packages/django/contrib/staticfiles/management/commands/collectstatic.py", line 125, in collect
    raise processed
ValueError: The file 'daisydiff/images/diffunderline.gif' could not be found with <require.storage.OptimizedCachedStaticFilesStorage object at 0x8e2424c>.



Fatal error: run() received nonzero return code 1 while executing!

Requested: python manage.py collectstatic --noinput
Executed: /bin/bash -l -c "cd /var/www/XXXX && source /var/python-environments/XXXX/bin/activate && python manage.py collectstatic --noinput"
```

## Analysis

r.js was trying to find the non-existent images, even though they were commented out.

## Proposed Solution

I just removed the comments.

It works after that.