### PR TITLE
More informative messages for compatibility errors

### DIFF
--- a/tests/core_tests/tests/test_core.py
+++ b/tests/core_tests/tests/test_core.py
@@ -61,15 +61,28 @@ class TestCore(RootNodeTestCase):
         self.assertEqual(len(self.root_node.get_descendants()), 50 + 2)
 
     def test_validate_relationship_cls(self):
-        with self.assertRaises(ChildWasRejected):
+        try:
             self.widgy_site.validate_relationship(self.root_node.content, RawTextWidget)
+        except ChildWasRejected as e:
+            self.assertIn("Layout refuses to accept RawTextWidget.", str(e))
+            self.assertTrue(e.message_dict)
+        else:
+            assert False, "Should have raised a ChildWasRejected exception"
 
         bucket = list(self.root_node.content.get_children())[0]
-        with self.assertRaises(ParentWasRejected):
+        try:
             self.widgy_site.validate_relationship(bucket, CantGoAnywhereWidget)
+        except ParentWasRejected as e:
+            self.assertIn("CantGoAnywhereWidget refuses to be put in Bucket.", str(e))
+        else:
+            assert False, "Should have raised a ParentWasRejected exception"
 
-        with self.assertRaises(MutualRejection):
+        try:
             self.widgy_site.validate_relationship(self.root_node.content, CantGoAnywhereWidget)
+        except MutualRejection as e:
+            self.assertIn("Neither Layout nor CantGoAnywhereWidget want to be together.", str(e))
+        else:
+            assert False, "Should have raised a MutualRejection exception"
 
     def test_validate_relationship_instance(self):
         picky_bucket = self.root_node.content.add_child(self.widgy_site,

--- a/widgy/exceptions.py
+++ b/widgy/exceptions.py
@@ -4,46 +4,43 @@ from django.core.exceptions import ValidationError
 class InvalidOperation(ValidationError):
     pass
 
+
 class InvalidTreeMovement(InvalidOperation):
     """
     Inherits from ``django.core.exceptions.ValidationError``.
 
     Base exception for all erroneous node restructures.
     """
-    pass
+    def __init__(self, message):
+        # If we don't do this, there won't be a message_dict.
+        super(InvalidTreeMovement, self).__init__({'message': [message]})
 
 
 class RootDisplacementError(InvalidTreeMovement):
     """
     Raise when trying to add siblings to a root node.
     """
-    pass
 
 
 class ParentChildRejection(InvalidTreeMovement):
     """
     General exception for when a child rejects a parent or vice versa.
     """
-    def __init__(self):
-        super(ParentChildRejection, self).__init__({'message': self.message})
 
 
 class ParentWasRejected(ParentChildRejection):
     """
     Raised by child to reject the requested parent.
     """
-    message = "This content does not accept being a child of that parent."
 
 
 class ChildWasRejected(ParentChildRejection):
     """
     Raised by parents to reject children that don't belong.
     """
-    message = "The parent does not accept this content as a child."
 
 
 class MutualRejection(ParentWasRejected, ChildWasRejected):
     """
     For instances where both child and parent reject the movement request.
     """
-    message = "Neither the parent or child accept this parent-child relationship."

--- a/widgy/site.py
+++ b/widgy/site.py
@@ -150,11 +150,20 @@ class WidgySite(object):
         bad_parent = not self.valid_child_of(parent, child_class, child)
 
         if bad_parent and bad_child:
-            raise MutualRejection
+            raise MutualRejection("Neither {parent} nor {child} want to be together.".format(
+                child=child_class.__name__,
+                parent=type(parent).__name__,
+            ))
         elif bad_parent:
-            raise ParentWasRejected
+            raise ParentWasRejected("{child} refuses to be put in {parent}.".format(
+                child=child_class.__name__,
+                parent=type(parent).__name__,
+            ))
         elif bad_child:
-            raise ChildWasRejected
+            raise ChildWasRejected("{parent} refuses to accept {child}.".format(
+                child=child_class.__name__,
+                parent=type(parent).__name__,
+            ))
 
     def get_version_tracker_model(self):
         from widgy.models import VersionTracker


### PR DESCRIPTION
This is an incremental improvement.

Space for improvement would include something like suggesting where to look to fix the problem. For example, I was imagining an error message like this:

    CantGoAnywhereWidget refuses to be put in Bucket. Maybe you should write a valid_child_of method for CantGoAnywhereWidget. To learn more visit the docs on compatibility (http://docs.wid.gy/en/latest/compatibility.html).

But I'm worried that the suggestion might be a misleading in some cases.