### PR TITLE
HiddenInput Django 1.7 admin compatibility

### DIFF
--- a/widgy/forms.py
+++ b/widgy/forms.py
@@ -30,6 +30,7 @@ class WidgyWidget(forms.HiddenInput):
     for a Widgy field.
     """
     template_name = 'widgy/widgy_field.html'
+    is_hidden = False
 
     def render(self, name, value, attrs=None, context={}):
         # If this fails, perhaps they aren't using the WidgyFormMixin.  If you


### PR DESCRIPTION
The whole row containing HiddenInput is hidden in django 1.7. WidgyWidget is implemented as a HiddenInput but shouldn't be hidden. Setting is_hidden=False tells the admin to show its row.