### PR TITLE
widgy_mezzanine preview doesn't work with default nginx config

### DIFF
--- a/widgy/contrib/widgy_mezzanine/models.py
+++ b/widgy/contrib/widgy_mezzanine/models.py
@@ -28,7 +28,7 @@ class WidgyPageMixin(object):
             'widgy.contrib.widgy_mezzanine.views.handle_form',
             kwargs={
                 'form_node_pk': form.node.pk,
-                'slug': self.slug,
+                'page_pk': self.pk,
             })
 
     def get_action_links(self, root_node):
@@ -38,7 +38,7 @@ class WidgyPageMixin(object):
                 'text': _('Preview'),
                 'url': urlresolvers.reverse(
                     'widgy.contrib.widgy_mezzanine.views.preview',
-                    kwargs={'slug': self.slug, 'node_pk': root_node.pk}
+                    kwargs={'page_pk': self.pk, 'node_pk': root_node.pk}
                 )
             },
         ]

--- a/widgy/contrib/widgy_mezzanine/tests.py
+++ b/widgy/contrib/widgy_mezzanine/tests.py
@@ -206,7 +206,7 @@ class TestPreviewView(TestCase):
         root_node1 = Button.add_root(widgy_site, text='Test 1')
         root_node2 = Button.add_root(widgy_site, text='Test 2')
 
-        resp1 = self.preview_view(self.request, node_pk=root_node1.node.pk, slug=page.slug)
+        resp1 = self.preview_view(self.request, node_pk=root_node1.node.pk, page_pk=page.pk)
 
         self.assertEqual(resp1.status_code, 200)
         self.assertIn('Test 1', resp1.rendered_content)

--- a/widgy/contrib/widgy_mezzanine/urls.py
+++ b/widgy/contrib/widgy_mezzanine/urls.py
@@ -2,6 +2,6 @@ from django.conf.urls import patterns, url
 
 urlpatterns = patterns('widgy.contrib.widgy_mezzanine.views',
     url('^preview/(?P<node_pk>[^/]+)/$', 'preview'),  # undelete
-    url('^preview/(?P<node_pk>[^/]+)/(?P<slug>.+)/$', 'preview'),
-    url('^form/(?P<form_node_pk>[^/]*)/(?P<slug>.+)/$', 'handle_form'),
+    url('^preview/(?P<node_pk>[^/]+)/(?P<page_pk>.+)/$', 'preview'),
+    url('^form/(?P<form_node_pk>[^/]*)/(?P<page_pk>.+)/$', 'handle_form'),
 )

--- a/widgy/contrib/widgy_mezzanine/views.py
+++ b/widgy/contrib/widgy_mezzanine/views.py
@@ -49,7 +49,7 @@ def get_page_from_node(node):
 class PageViewMixin(object):
     def get_page(self):
         try:
-            return Page.objects.published(for_user=self.request.user).get(slug=self.kwargs['slug'])
+            return Page.objects.published(for_user=self.request.user).get(pk=self.kwargs['page_pk'])
         except (KeyError, Page.DoesNotExist):
             # restoring, use a fake page
             return WidgyPage(


### PR DESCRIPTION
nginx has a feature where it merges slashes[0] in a URL, so for example, a URL that looks like:

```
//scripts/script.php
```

would be normalized to:

```
/scripts/script.php
```

This is great, except no it's not.  Especially because in widgy, we tend to have URLs that look like:

```
http://demo.wid.gy/widgy/preview/1///
```

but that nginx is passing through as:

```
http://demo.wid.gy/widgy/preview/1/
```

The behavior in nginx can be turned off with

```
merge_slashes off;
```

But it seems bad to require special configuration of nginx for widgy to work. Alternatively, we can urlencode the slug in the url.


[0] http://nginx.org/en/docs/http/ngx_http_core_module.html#merge_slashes

reported by @rockymeza 