### PR TITLE
Preserve the old preview/form urls for backwards compatibility

### DIFF
--- a/widgy/contrib/widgy_mezzanine/models.py
+++ b/widgy/contrib/widgy_mezzanine/models.py
@@ -28,7 +28,7 @@ class WidgyPageMixin(object):
             'widgy.contrib.widgy_mezzanine.views.handle_form',
             kwargs={
                 'form_node_pk': form.node.pk,
-                'page_pk': self.pk,
+                'slug': self.pk,
             })
 
     def get_action_links(self, root_node):

--- a/widgy/contrib/widgy_mezzanine/urls.py
+++ b/widgy/contrib/widgy_mezzanine/urls.py
@@ -2,6 +2,10 @@ from django.conf.urls import patterns, url
 
 urlpatterns = patterns('widgy.contrib.widgy_mezzanine.views',
     url('^preview/(?P<node_pk>[^/]+)/$', 'preview'),  # undelete
-    url('^preview/(?P<node_pk>[^/]+)/(?P<page_pk>.+)/$', 'preview'),
-    url('^form/(?P<form_node_pk>[^/]*)/(?P<page_pk>.+)/$', 'handle_form'),
+    url('^preview-page/(?P<node_pk>[^/]+)/(?P<page_pk>[^/]+)/$', 'preview'),
+    url('^form-page/(?P<form_node_pk>[^/]*)/(?P<page_pk>[^/]+)/$', 'handle_form'),
+
+    # deprecated urls for backwards compatibility with slug reversing
+    url('^preview/(?P<node_pk>[^/]+)/(?P<slug>.+)/$', 'preview'),
+    url('^form/(?P<form_node_pk>[^/]*)/(?P<slug>.+)/$', 'handle_form'),
 )


### PR DESCRIPTION
If you're reversing the preview url by slug, your code should continue to work. This fixes the backwards compatibility problems for #233.