### PR TITLE
Accessing a preview page unauthenticated should redirect to the admin login form

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,15 @@ Changelog
   see the `django-pyscss changelog
   <https://pypi.python.org/pypi/django-pyscss/2.0.0#changelog>`_ for
   documentation on how/if you need to change anything.
+- By default, Widgy views are restricted to staff members. Previously any
+  authenticated user was allowed. This effects the preview view and pop out
+  edit view, among others. If you were relying on the ability for any user to
+  access those, override ``authorize_view`` in your ``WidgySite``. ::
+
+    class MyWidgySite(WidgySite):
+        def authorize_view(self, request, view):
+            if not request.user.is_authenticated()
+                raise PermissionDenied
 
 
 0.5.0 (2015-04-17)

--- a/demo/settings.py
+++ b/demo/settings.py
@@ -204,3 +204,4 @@ WIDGY_MEZZANINE_SITE = 'demo.widgysite.widgy_site'
 
 
 DATABASE_ENGINE = DATABASES['default']['ENGINE']
+LOGIN_URL = '/admin/'

--- a/tests/core_tests/tests/base.py
+++ b/tests/core_tests/tests/base.py
@@ -20,12 +20,11 @@ class HttpTestCase(TestCase):
     def setUp(self):
         super(HttpTestCase, self).setUp()
 
-        u = User.objects.create_user(
+        u = User.objects.create_superuser(
             username='testuser',
             email='asdf@example.com',
             password='asdfasdf',
         )
-        u.is_superuser = True
         u.save()
         self.client.login(username=u.username, password='asdfasdf')
         self.user = u

--- a/tests/core_tests/tests/test_api.py
+++ b/tests/core_tests/tests/test_api.py
@@ -538,7 +538,7 @@ class PermissionsTest(SwitchUserTestCase, RootNodeTestCase, HttpTestCase):
 
         def fail():
             resp = doit()
-            self.assertEqual(resp.status_code, 403)
+            self.assertIn(resp.status_code, (403, 302))
 
         def win():
             resp = doit()

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -92,7 +92,8 @@ MEDIA_ROOT = os.path.join(TEMP_DIR, 'media')
 TEMPLATE_DIRS = (os.path.join(RUNTESTS_DIR, TEST_TEMPLATE_DIR),)
 USE_I18N = True
 LANGUAGE_CODE = 'en'
-LOGIN_URL = 'django.contrib.auth.views.login'
+# BBB: Django 1.4 doesn't reverse LOGIN_URL
+LOGIN_URL = '/accounts/login/'
 
 STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.FileSystemFinder',

--- a/widgy/contrib/widgy_mezzanine/tests.py
+++ b/widgy/contrib/widgy_mezzanine/tests.py
@@ -227,7 +227,7 @@ class TestPreviewView(UserSetup, TestCase):
         self.factory = RequestFactory()
         self.preview_view = PreviewView.as_view(site=widgy_site)
         self.request = self.factory.get('/')
-        self.request.user = User(is_superuser=True)
+        self.request.user = User(is_superuser=True, is_staff=True)
 
     def test_preview(self):
         page = WidgyPage.objects.create(title='Test')

--- a/widgy/site.py
+++ b/widgy/site.py
@@ -69,7 +69,7 @@ class WidgySite(object):
         return reverse(*args, **kwargs)
 
     def authorize_view(self, request, view):
-        if not request.user.is_authenticated():
+        if not (request.user.is_authenticated() and request.user.is_staff):
             raise PermissionDenied
 
     def has_add_permission(self, request, content_class):


### PR DESCRIPTION
Hi,

When a colleague sends me a link to a preview page in widgy, I get a 403 Permission denied page.

We should redirect to the admin login form, it would improve the user experience.