### PR TITLE
Widgy doesn't support CSRF_COOKIE_HTTPONLY

### DIFF
--- a/widgy/static/widgy/js/lib/csrf.js
+++ b/widgy/static/widgy/js/lib/csrf.js
@@ -18,6 +18,25 @@ define([ 'jquery' ], function(jQuery){
     return cookieValue;
   })('csrftoken');
 
+  if (!csrftoken) {
+    // The CSRF token was not set, perhaps they are using
+    // CSRF_COOKIE_HTTPONLY.
+    csrftoken = $('[name=csrfmiddlewaretoken]').val();
+  }
+
+  if (!csrftoken) {
+    console.error(
+      "Widgy couldn't figure out the CSRF token. It checked two places:\n" +
+      " - The csrftoken cookie (not available if CSRF_COOKIE_HTTPONLY is set" +
+      " to True\n" +
+      " - The csrfmiddlewaretoken hidden input provided by the csrftoken" +
+      " template tag\n" +
+      " If you can change neither of these problems, please open an issue on" +
+      " http://github.com/fusionbox/django-widgy/issues explaining your" +
+      " situation."
+    );
+  }
+
   function csrfSafeMethod(method) {
     // these HTTP methods do not require CSRF protection
     return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));


### PR DESCRIPTION
Currently widgy is grabbing the csrf token out of the cookie using JavaScript. This fails if you set `CSRF_COOKIE_HTTPONLY=True`. 

We should change how we do that. I think we could just pass the csrf token in manually to the javascript.