### PR TITLE
We need to support django-pyscss 2.0.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,10 @@ Changelog
 0.6.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- **Possible Breaking Change** Updated the django-pyscss_ dependency. Please
+  see the `django-pyscss changelog
+  <https://pypi.python.org/pypi/django-pyscss/2.0.0#changelog>`_ for
+  documentation on how/if you need to change anything.
 
 
 0.5.0 (2015-04-17)

--- a/demo/public/css/demo.scss
+++ b/demo/public/css/demo.scss
@@ -194,7 +194,7 @@ form {
   border: 1px dashed $almostwhite;
   clear: both;
   margin-bottom: 20px;
-  padding: 20px
+  padding: 20px;
 
   div.formField {
     @include clearfix;

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ def read(fname):
 # <https://bitbucket.org/pypa/setuptools/issue/196/tests_require-pytest-pytest-cov-breaks>.
 install_requires = [
     'django-treebeard',
-    'django-pyscss',
+    'django-pyscss>=2.0.0',
     'six',
     'django-compressor>=1.3',
     'beautifulsoup4',

--- a/widgy/contrib/page_builder/forms/__init__.py
+++ b/widgy/contrib/page_builder/forms/__init__.py
@@ -7,7 +7,7 @@ from django.template.loader import render_to_string
 from django.conf import settings
 
 import bleach
-from django_pyscss.scss import DjangoScss
+from django_pyscss import DjangoScssCompiler
 
 
 PAGEDOWN_EDITOR_TEMPLATE = u'''
@@ -18,8 +18,8 @@ PAGEDOWN_EDITOR_TEMPLATE = u'''
 
 
 def scss_compile(scss_filename):
-    scss = DjangoScss()
-    css_content = scss.compile(scss_file=scss_filename)
+    scss = DjangoScssCompiler()
+    css_content = scss.compile(scss_filename)
     return css_content
 
 


### PR DESCRIPTION
I was hoping that we could get the commits 757ef9d and db4129b into master without waiting for mezzanine and django-filer to be released.
