### PR TITLE
mezzanine.boot shouldn't be recommended

### DIFF
--- a/demo/settings.py
+++ b/demo/settings.py
@@ -28,7 +28,6 @@ INSTALLED_APPS = (
     'django.contrib.staticfiles',
     'django.contrib.sites',
 
-    'mezzanine.boot',
     'mezzanine.conf',
     'mezzanine.core',
     'mezzanine.generic',

--- a/docs/tutorials/widgy-mezzanine-tutorial.rst
+++ b/docs/tutorials/widgy-mezzanine-tutorial.rst
@@ -14,7 +14,6 @@ Install the Widgy package::
 
 Add Mezzanine apps to ``INSTALLED_APPS``::
 
-        'mezzanine.boot',
         'mezzanine.conf',
         'mezzanine.core',
         'mezzanine.generic',

--- a/tests/settings_contrib.py
+++ b/tests/settings_contrib.py
@@ -6,7 +6,6 @@ PACKAGE_NAME_GRAPPELLI = "grappelli_safe"
 GRAPPELLI_INSTALLED = True
 
 INSTALLED_APPS += [
-    'mezzanine.boot',
     'mezzanine.conf',
     'mezzanine.core',
     'mezzanine.generic',


### PR DESCRIPTION
I don't think mezzanine.boot needs to be installed -- it's only for monkey patching EXTRA_MODEL_FIELDS http://mezzanine.jupo.org/docs/packages.html#module-mezzanine.boot. It does the lazy admin registration thing, which always causes hard to debug problems. We should remove it if it's not required.