### PR TITLE
Remove dependency for ReviewedVersionTracker in migrations

### DIFF
--- a/widgy/contrib/widgy_mezzanine/migrations/0001_initial.py
+++ b/widgy/contrib/widgy_mezzanine/migrations/0001_initial.py
@@ -11,7 +11,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('pages', '__first__'),
-        ('review_queue', '0001_initial'),
+        ('widgy', '0001_initial'),
     ]
 
     operations = [
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
             name='WidgyPage',
             fields=[
                 ('page_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='pages.Page')),
-                ('root_node', widgy.db.fields.VersionedWidgyField(on_delete=django.db.models.deletion.SET_NULL, verbose_name='widgy content', to='review_queue.ReviewedVersionTracker', null=True)),
+                ('root_node', widgy.db.fields.VersionedWidgyField(on_delete=django.db.models.deletion.SET_NULL, verbose_name='widgy content', to='widgy.VersionTracker', null=True)),
             ],
             options={
                 'ordering': ('_order',),


### PR DESCRIPTION
The base widgy migrations had references to ReviewedVersionTracker,
which is not part of the base widgy install.  This commit changes the
dependency to VersionTracker instead, which is part of the base widgy
install.