### PR TITLE
Remove `south` from required widgy apps

### DIFF
--- a/docs/tutorials/widgy-mezzanine-tutorial.rst
+++ b/docs/tutorials/widgy-mezzanine-tutorial.rst
@@ -37,7 +37,6 @@ add required Widgy apps to ``INSTALLED_APPS``::
         'compressor',
         'argonauts',
         'sorl.thumbnail',
-        'south',
 
 
 ``django.contrib.admin`` should be installed after Mezzanine and Widgy,


### PR DESCRIPTION
`south` is no longer installed as a part of `django-widgy[all]`. This
patch removes it from the tutorial.