### PR TITLE
Add staticfiles import for widgypage_base.html

### DIFF
--- a/widgy/contrib/widgy_mezzanine/templates/pages/widgypage_base.html
+++ b/widgy/contrib/widgy_mezzanine/templates/pages/widgypage_base.html
@@ -10,6 +10,7 @@ defaultlayout templating. See https://github.com/fusionbox/django-widgy/pull/41
 {% load widgy_tags %}
 {% load pages_tags %}
 {% load compress %}
+{% load staticfiles %}
 
 {% block title %}{{ page.meta_title }} {{ block.super }}{% endblock %}
 {% block css %}


### PR DESCRIPTION
This file is only used by the oldest widgy projects, but when using
django-compressor's offline mode, it will trigger an error because it is
missing the staticfiles templatetags library.