### PR TITLE
hide empty node shelves

### DIFF
--- a/widgy/static/widgy/css/widgy_theme_default.scss
+++ b/widgy/static/widgy/css/widgy_theme_default.scss
@@ -232,6 +232,10 @@ $font-default: "Open Sans", Arial, Helvetica, sans-serif;
   .node:not(section) .shelf {
     border-bottom: 2px solid $lightgrey;
     padding: 10px 0 5px 1em;
+    
+    &.empty {
+      display: none;
+    }
   }
 }
 


### PR DESCRIPTION
This CSS change hides empty widget shelves (the label "Widgets" and the double-thick underline) to clean up the layout once the shelf has been depleted.