### PR TITLE
Update video widget to work with Django 1.8

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,6 @@ basepython=
   py34: python3.4
 commands=
   contrib: pip install -e .[page_builder,widgy_mezzanine,form_builder] --log-file {envdir}/pip-extras-require-log.log
-  /usr/bin/env
   py.test
 setenv=
   DJANGO_SETTINGS_MODULE=tests.settings

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ basepython=
   py34: python3.4
 commands=
   contrib: pip install -e .[page_builder,widgy_mezzanine,form_builder] --log-file {envdir}/pip-extras-require-log.log
-  py.test
+  py.test {posargs}
 setenv=
   DJANGO_SETTINGS_MODULE=tests.settings
   sqlite: DATABASE_URL=sqlite:///test_db.sqlite3

--- a/widgy/contrib/page_builder/db/fields.py
+++ b/widgy/contrib/page_builder/db/fields.py
@@ -80,9 +80,7 @@ def validators_video_url(value):
         raise forms.ValidationError(_('Not a valid YouTube or Vimeo URL'))
 
 
-class VideoField(models.URLField):
-    __metaclass__ = models.SubfieldBase
-
+class VideoField(six.with_metaclass(models.SubfieldBase, models.URLField)):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('help_text', _('Please enter a link to the YouTube or'
                                          ' Vimeo page for this video.  i.e.'

--- a/widgy/contrib/page_builder/db/fields.py
+++ b/widgy/contrib/page_builder/db/fields.py
@@ -90,7 +90,14 @@ class VideoField(models.URLField):
         super(VideoField, self).__init__(*args, **kwargs)
         self.validators.append(validators_video_url)
 
+    def from_db_value(self, value, expression, connection, context):
+        """Convert from db starting in Django 1.8"""
+        if value is None:
+            return value
+        return self.get_url_instance(value)
+
     def to_python(self, value):
+        """Convert from db in Django < 1.8"""
         url = super(VideoField, self).to_python(value)
         if url is None:
             return url

--- a/widgy/contrib/page_builder/tests.py
+++ b/widgy/contrib/page_builder/tests.py
@@ -7,7 +7,7 @@ from widgy.exceptions import ParentChildRejection
 
 from widgy.contrib.page_builder.models import (
     Table, TableRow, TableHeaderData, TableHeader, TableBody,
-    Accordion, Video
+    Accordion, Video, MainContent
 )
 from widgy.contrib.page_builder.forms import CKEditorField
 
@@ -233,7 +233,12 @@ class TestVideoWidget(TestCase):
     def test_video_has_url(self):
         """Test video fetch from database."""
 
-        video = Video.objects.create(video='https://www.youtube.com/watch?v=dQw4w9WgXcQ')
-        video = Video.objects.get(pk=video.pk)
+        content = MainContent.add_root(widgy_site)
+        video = content.add_child(
+            widgy_site,
+            Video,
+            video='https://www.youtube.com/watch?v=dQw4w9WgXcQ'
+        )
 
+        video = content.get_children()[0]
         self.assertEqual(video.video.embed_url, '//youtube.com/embed/dQw4w9WgXcQ')

--- a/widgy/contrib/page_builder/tests.py
+++ b/widgy/contrib/page_builder/tests.py
@@ -7,7 +7,7 @@ from widgy.exceptions import ParentChildRejection
 
 from widgy.contrib.page_builder.models import (
     Table, TableRow, TableHeaderData, TableHeader, TableBody,
-    Accordion,
+    Accordion, Video
 )
 from widgy.contrib.page_builder.forms import CKEditorField
 
@@ -227,3 +227,13 @@ class TestAccordionAutomaticallyAdds2Sections(TestCase):
         self.assertEqual(len(tabs.get_children()), 2)
         self.assertEqual(tabs.get_children()[0].title, 'Title 1')
         self.assertEqual(tabs.get_children()[1].title, 'Title 2')
+
+
+class TestVideoWidget(TestCase):
+    def test_video_has_url(self):
+        """Test video fetch from database."""
+
+        video = Video.objects.create(video='https://www.youtube.com/watch?v=dQw4w9WgXcQ')
+        video = Video.objects.get(pk=video.pk)
+
+        self.assertEqual(video.video.embed_url, '//youtube.com/embed/dQw4w9WgXcQ')


### PR DESCRIPTION
In Django 1.8 to_python is not automatically called by SubfieldBase
any more. Django 1.8 provides a new method: from_db_value.

See:
https://docs.djangoproject.com/en/1.8/howto/custom-model-fields/#converting-values-to-python-objects
https://docs.djangoproject.com/en/1.8/ref/models/fields/#django.db.models.Field.from_db_value

(Note: super() may not be called in from_db_value())