### PR TITLE
Take widgypage_pre_index out of widgy_mezzanine and into widgy

### DIFF
--- a/widgy/contrib/urlconf_include/signalhandlers.py
+++ b/widgy/contrib/urlconf_include/signalhandlers.py
@@ -3,11 +3,11 @@ from django.dispatch import receiver
 from django.conf import settings
 from django.utils.importlib import import_module
 
-from widgy.contrib.widgy_mezzanine.signals import widgypage_pre_index
+from widgy.signals import widgy_pre_index
 
 
 
-@receiver(widgypage_pre_index)
+@receiver(widgy_pre_index)
 def patch_url_conf(sender, **kwargs):
     from .middleware import PatchUrlconfMiddleware
     root_urlconf = import_module(settings.ROOT_URLCONF)

--- a/widgy/contrib/widgy_mezzanine/search_indexes.py
+++ b/widgy/contrib/widgy_mezzanine/search_indexes.py
@@ -4,7 +4,7 @@ from widgy.contrib.widgy_mezzanine import get_widgypage_model
 from widgy.templatetags.widgy_tags import render_root
 from widgy.utils import html_to_plaintext
 
-from .signals import widgypage_pre_index
+from widgy.signals import widgy_pre_index
 
 WidgyPage = get_widgypage_model()
 
@@ -18,7 +18,7 @@ class PageIndex(indexes.SearchIndex, indexes.Indexable):
     text = indexes.CharField(document=True)
 
     def full_prepare(self, *args, **kwargs):
-        widgypage_pre_index.send(sender=self)
+        widgy_pre_index.send(sender=self)
         return super(PageIndex, self).full_prepare(*args, **kwargs)
 
     def get_model(self):

--- a/widgy/contrib/widgy_mezzanine/signals.py
+++ b/widgy/contrib/widgy_mezzanine/signals.py
@@ -1,3 +1,12 @@
-from django.dispatch import Signal
+import warnings
 
-widgypage_pre_index = Signal()
+from widgy.signals import widgy_pre_index
+
+
+warnings.warn(
+    "widgy.contrib.widgy_mezzanine.signals.widgypage_pre_index is deprecated. "
+    "Use widgy.signals.widgy_pre_index instead.",
+    DeprecationWarning,
+)
+
+widgypage_pre_index = widgy_pre_index

--- a/widgy/signals.py
+++ b/widgy/signals.py
@@ -2,3 +2,4 @@ from django.dispatch import Signal
 
 
 pre_delete_widget = Signal(providing_args=['instance', 'raw'])
+widgy_pre_index = Signal()


### PR DESCRIPTION
It's now called widgy_pre_index. This is necessary for django-widgy-blog, which also needs to send a pre-index signal but shouldn't depend on widgy_mezzanine.