### PR TITLE
Make HtmlForm content required.

### DIFF
--- a/widgy/contrib/page_builder/models.py
+++ b/widgy/contrib/page_builder/models.py
@@ -103,7 +103,7 @@ class Markdown(Content):
 
 
 class HtmlForm(forms.ModelForm):
-    content = CKEditorField(required=False, label=_('Content'))
+    content = CKEditorField(label=_('Content'))
 
 
 @widgy.register


### PR DESCRIPTION
This is required to match the model (blank = False).  This should have
been done in 8dbdd79f26, but it was incomplete.