### PR TITLE
Handle widgets with ManyToManyFields better

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,11 @@ Changelog
   see the `django-pyscss changelog
   <https://pypi.python.org/pypi/django-pyscss/2.0.0#changelog>`_ for
   documentation on how/if you need to change anything.
+- ``Content.clone`` now copies simple many-to-many relationships. If you have a
+  widget with a many-to-many field and an overridden clone method that calls
+  super, you should take this into account. If you have many-to-many
+  relationships that use a custom through table, you will have to continue to
+  override clone to clone those.
 
 
 0.6.1 (2015-05-01)

--- a/tests/core_tests/migrations/0002_auto_20150701_1654.py
+++ b/tests/core_tests/migrations/0002_auto_20150701_1654.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core_tests', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='ManyToManyWidget',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+            ],
+        ),
+        migrations.CreateModel(
+            name='Tag',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('name', models.CharField(unique=True, max_length=100)),
+            ],
+        ),
+        migrations.AddField(
+            model_name='manytomanywidget',
+            name='tags',
+            field=models.ManyToManyField(to='core_tests.Tag'),
+        ),
+    ]

--- a/tests/core_tests/models.py
+++ b/tests/core_tests/models.py
@@ -284,3 +284,12 @@ class VerboseNameLayout(Content):
 class VerboseNameLayoutChild(VerboseNameLayout):
     class Meta:
         verbose_name = 'Foobar'
+
+
+class Tag(models.Model):
+    name = models.CharField(unique=True, max_length=100)
+
+
+@registry.register
+class ManyToManyWidget(Content):
+    tags = models.ManyToManyField(Tag)

--- a/tests/core_tests/tests/test_core.py
+++ b/tests/core_tests/tests/test_core.py
@@ -24,8 +24,8 @@ from ..models import (
     Layout, Bucket, RawTextWidget, CantGoAnywhereWidget, PickyBucket,
     ImmovableBucket, AnotherLayout, VowelBucket, VersionedPage, VersionedPage2,
     VersionedPage3, VersionedPage4, VersionPageThrough, Related,
-    ForeignKeyWidget, WeirdPkBucket, UnnestableWidget,
-    CssClassesWidget, CssClassesWidgetSubclass, CssClassesWidgetProperty,
+    ForeignKeyWidget, WeirdPkBucket, UnnestableWidget, CssClassesWidget,
+    CssClassesWidgetSubclass, CssClassesWidgetProperty, ManyToManyWidget, Tag
 )
 from .base import (
     RootNodeTestCase, make_a_nice_tree, SwitchUserTestCase, refetch)
@@ -274,6 +274,12 @@ class TestCore(RootNodeTestCase):
             self.assertEqual(widget.get_attributes(),
                              attributes)
 
+        widget = ManyToManyWidget.add_root(self.widgy_site)
+        tag = Tag.objects.create(name='foo')
+        widget.tags.add(tag)
+        widget.save()
+        self.assertEqual(widget.get_attributes(), {'tags': [tag.pk]})
+
 
 class TestRegistry(RootNodeTestCase):
     def setUp(self):
@@ -399,11 +405,13 @@ class TestVersioning(RootNodeTestCase):
         root_node = root.node
         root_node.prefetch_tree()
 
+        # - savepoint
         # - root content (1 query)
-        # - root node (2 queries)
-        # - 2 text contents (2 queries)
+        # - release savepoint
+        # - root node (2 queries, 2 savepoints)
+        # - 2 text contents (2 queries, 2 savepoints)
         # - subnodes (1 query)
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(12):
             root_node.clone_tree()
 
     def test_content_equal(self):
@@ -866,6 +874,14 @@ class TestVersioning(RootNodeTestCase):
         root = WeirdPkBucket.add_root(self.widgy_site, bubble=2)
         new_root = root.clone()
         self.assertNotEqual(new_root.pk, root.pk)
+
+    def test_clone_m2m(self):
+        tag = Tag.objects.create(name='foo')
+        root = ManyToManyWidget.add_root(self.widgy_site)
+        root.tags.add(tag)
+
+        new_root = root.clone()
+        self.assertEqual(new_root.tags.get(), tag)
 
     def test_reset_exception(self):
         """


### PR DESCRIPTION
  - Content.clone() now copies them
  - Content.get_attributes() includes them so widgets with changed
    many-to-manies are considered not equal().