### PR TITLE
VersionTracker with commits were filtered out from orphan()

### DIFF
--- a/tests/core_tests/tests/test_core.py
+++ b/tests/core_tests/tests/test_core.py
@@ -699,6 +699,18 @@ class TestVersioning(RootNodeTestCase):
         a.delete()
         self.assertEqual(list(VersionTracker.objects.orphan()), [vt])
 
+        vt.delete()
+
+        vt, a, b, c = self.orphan_helper()
+        vt.commit()
+        self.assertEqual(list(VersionTracker.objects.orphan()), [])
+        c.delete()
+        self.assertEqual(list(VersionTracker.objects.orphan()), [])
+        b.delete()
+        self.assertEqual(list(VersionTracker.objects.orphan()), [])
+        a.delete()
+        self.assertEqual(list(VersionTracker.objects.orphan()), [vt])
+
     def test_orphan_no_related_name(self):
         # VersionedPage3 doesn't have a related_name on its
         # VersionedWidgyField. Not having a related name is how you

--- a/widgy/models/versioning.py
+++ b/widgy/models/versioning.py
@@ -60,7 +60,7 @@ class VersionTracker(models.Model):
             filters = {}
             for rel_obj in (self.model._meta.get_all_related_objects() +
                             self.model._meta.get_all_related_many_to_many_objects()):
-                if not issubclass(rel_obj.model, VersionCommit):
+                if not issubclass(rel_obj.field.model, VersionCommit):
                     name = rel_obj.field.related_query_name()
                     filters[name + '__isnull'] = True
             return self.filter(**filters)


### PR DESCRIPTION
In Django 1.7 and 1.8 relation.model is the model the relation is
pointing from. Therefore `issubclass(rel_obj.model, VersionCommit)` was
always false, since `rel_obj.model` was either VersionTracker or
ReviewedVersionTracker.