### PR TITLE
Make friendly_uuid work correctly on Python 3

### DIFF
--- a/widgy/contrib/form_builder/models.py
+++ b/widgy/contrib/form_builder/models.py
@@ -443,8 +443,13 @@ def friendly_uuid(uuid):
     The returned string will have 40 bits of entropy assuming a UUID4.
     """
     result = base64.b32encode(hashlib.sha1(force_bytes(uuid)).digest()[:5]).lower()
+    unicode_result = result.decode('ascii')
     # avoid accidental profanity
-    return result.replace(b'e', b'0').replace(b'o', b'1').replace(b'u', b'8').replace(b'i', b'9')
+    profanity_filter = (unicode_result.replace('e', '0')
+                                      .replace('o', '1')
+                                      .replace('u', '8')
+                                      .replace('i', '9'))
+    return profanity_filter
 
 
 @widgy.register

--- a/widgy/contrib/form_builder/tests.py
+++ b/widgy/contrib/form_builder/tests.py
@@ -1,6 +1,8 @@
 from __future__ import unicode_literals
 
 import contextlib
+import uuid
+
 from six.moves import StringIO
 
 from django.test import TestCase
@@ -18,7 +20,7 @@ import mock
 from widgy.contrib.form_builder.forms import PhoneNumberField
 from widgy.contrib.form_builder.models import (
     Form, FormInput, Textarea, FormSubmission, FormField, Uncaptcha,
-    EmailUserHandler, EmailSuccessHandler, FileUpload,
+    EmailUserHandler, EmailSuccessHandler, FileUpload, friendly_uuid
 )
 from widgy.exceptions import ParentChildRejection
 from widgy.utils import build_url
@@ -108,6 +110,18 @@ class TestForm(TestCase):
 
     def setUp(self):
         self.form, self.fields = self.make_form()
+
+    def test_friendly_uuid_python2_python3_plays_nice(self):
+        """
+        Regression test for friendly UUID.
+
+        friendly_uuid should return unicode for comparison with
+        values from a request.
+        """
+
+        test_uuid = uuid.UUID('{12345678-1234-5678-1234-567812345678}')
+        short_uuid = friendly_uuid(test_uuid)
+        assert short_uuid == '3cvd8mz9'
 
     def submit(self, a, b, c, form=None):
         form = form or self.form


### PR DESCRIPTION
friendly_uuid returns bytes on python3 which is then compared
with a string type which always returns false. friendly_uuid
should return a string type on both Python 2 and Python 3.