### PR TITLE
Remove deferred exceptions

### DIFF
--- a/tests/core_tests/tests/test_core.py
+++ b/tests/core_tests/tests/test_core.py
@@ -293,28 +293,20 @@ class TestRegistry(RootNodeTestCase):
     def test_register(self):
         self.registry.register(self.cls)
         self.assertIn(self.cls, self.registry)
-        self.registry.raise_deferred_exception()
 
     def test_unregister(self):
         self.registry.register(self.cls)
         self.registry.unregister(self.cls)
         self.assertNotIn(self.cls, self.registry)
-        self.registry.raise_deferred_exception()
 
     def test_register_twice(self):
         self.registry.register(self.cls)
-        with mock.patch('sys.stderr') as stderr:
-            with self.assertRaises(Exception):
-                self.registry.register(self.cls)
-                self.registry.raise_deferred_exception()
-            self.assertEqual(stderr.write.call_count, 1)
+        with self.assertRaises(Exception):
+            self.registry.register(self.cls)
 
     def test_unregister_not_registered(self):
-        with mock.patch('sys.stderr') as stderr:
-            with self.assertRaises(Exception):
-                self.registry.unregister(self.cls)
-                self.registry.raise_deferred_exception()
-            self.assertEqual(stderr.write.call_count, 1)
+        with self.assertRaises(Exception):
+            self.registry.unregister(self.cls)
 
 
 class TestTreesEqual(RootNodeTestCase):

--- a/widgy/__init__.py
+++ b/widgy/__init__.py
@@ -2,18 +2,21 @@ import traceback
 import sys
 
 from django.core.exceptions import ImproperlyConfigured
-from django.core.signals import request_started
 
 
 class BaseRegistry(set):
-    deferred_exception = None
+    """
+    Container class for unique Django models.
 
+    A model must be registered with a registry to be visible to Widgy.
+    """
     def register(self, model):
         from django.db import models
         if model in self:
-            self.defer_exception(ImproperlyConfigured(
-                "You cannot register the same model ('{0}') twice.".format(model)
-            ))
+            raise ImproperlyConfigured(
+                "You cannot register the same model ('{0}') twice."
+                .format(model)
+            )
         if not issubclass(model, models.Model):
             raise ImproperlyConfigured(("{0} is not a subclass of django.db.models.Model, "
                                         "so it cannot be registered").format(model))
@@ -25,50 +28,17 @@ class BaseRegistry(set):
         return model
 
     def unregister(self, model):
-        try:
-            self.remove(model)
-        except KeyError as e:
-            self.defer_exception(e)
-
-    def defer_exception(self, exception):
-        # XXX: this is a terrible hack to improve error reporting.
-        #
-        # Raising an exception here results in some awful error
-        # reporting when models.py modules have ImportError. Django
-        # will import the models module more than once, meaning
-        # classes will get registered more than once, and if we
-        # raise an exception here, you get an ImproperlyConfigured
-        # instead of the ImportError that would help you find the
-        # problem. See https://code.djangoproject.com/ticket/20839.
-        self.deferred_exception = exception
-        # sys._getframe(1) == skip defer_exception's frame, because it's
-        # not interesting
-        self.stacktrace = ''.join(traceback.format_stack(sys._getframe(1)))
-        # We need an opportunity to raise the exception. Anything will
-        # work as long as it happens after model loading. It'd be nice
-        # if it happened during validation and didn't wait until the
-        # first request, but there's no way to hook into that.
-        #
-        # The handler can't be registered in BaseRegistry.__init__
-        # because the tests import this module before settings are
-        # configured, and the signal can't be imported without settings.
-        def handler(**kwargs):
-            self.raise_deferred_exception()
-            request_started.disconnect(handler)
-        request_started.connect(handler, weak=False)
-
-    def raise_deferred_exception(self):
-        if self.deferred_exception:
-            # six.reraise doesn't keep the whole stack, so print a
-            # stacktrace to help find the error.
-            sys.stderr.write(self.stacktrace)
-            try:
-                raise self.deferred_exception
-            finally:
-                self.deferred_exception = None
+        self.remove(model)
 
 
 class Registry(BaseRegistry):
+    """
+    Container class for all widgets available for use in widgy.
+
+    A widget must be registered with the registry in order to appear in the
+    available widgets box.
+    """
+
     def register(self, content):
         from widgy.models import Content
         if not issubclass(content, Content):


### PR DESCRIPTION
The Django behavior that necessitated deferred exceptions in Widgy
was fixed in Django 1.7, which is the oldest version Widgy now supports.

Fix #288