### PR TITLE
Add documentation for mezzanine SitePermissions workaround

### DIFF
--- a/docs/tutorials/widgy-mezzanine-tutorial.rst
+++ b/docs/tutorials/widgy-mezzanine-tutorial.rst
@@ -47,6 +47,7 @@ add Mezzanine middleware to ``MIDDLEWARE_CLASSES``::
         'mezzanine.core.request.CurrentRequestMiddleware',
         'mezzanine.core.middleware.AdminLoginInterfaceSelectorMiddleware',
         'mezzanine.pages.middleware.PageMiddleware',
+        'mezzanine.core.middleware.SitePermissionMiddleware',
 
 Mezzanine settings::
 
@@ -156,6 +157,31 @@ will not work right.
 If you are using ``GenericTemplateFinderMiddleware``, use the one from
 ``fusionbox.mezzanine.middleware``. It has been patched to
 work with Mezzanine.
+
+Mezzanine SitePermissions
+-------------------------
+
+The Mezzanine SitePermissions system requires that any staff
+users be assigned site permissions to access the admin site. As an
+alternative to using ``mezzanine.core.middleware.SitePermissionMiddleware``
+you can override the base admin template by using the ``overextends`` template
+tag.
+
+To do this you will need to remove 
+``mezzanine.core.middleware.SitePermissionMiddleware``, add::
+
+    # settings.py
+    add_to_builtins("mezzanine.template.loader_tags")
+
+to enable the ``overextends`` template tag, and then override 
+``admin/base_site.html``::
+
+    {% overextends "admin/base_site.html" %}
+    {% block before_content %}{% endblock %}
+
+This will prevent mezzanine from displaying the site dropdown. Everything else
+should work as is.
+
 
 How to edit home page
 ---------------------


### PR DESCRIPTION
Right now, staff users in the admin in mezzanine require
the site permissions middleware. This fix adds that to
the tutorial, and also provides a workaround.