### PR TITLE
Serialize data for success emails properly

### DIFF
--- a/widgy/contrib/form_builder/models.py
+++ b/widgy/contrib/form_builder/models.py
@@ -243,9 +243,10 @@ class EmailSuccessHandlerBase(StrDisplayNameMixin, FormSuccessHandler):
         data = []
         # keep the data in the same order as the form
         for name, field in self.parent_form.get_fields().items():
-            data.append(
-                (field.label, form.cleaned_data[name])
+            serialized_value = field.serialize_value(
+                form.cleaned_data[name]
             )
+            data.append((field.label, serialized_value))
         return render_to_string('widgy/form_builder/form_email.html', {
             'data': data,
             'self': self,


### PR DESCRIPTION
Currently multiple choice field data in emails takes the form of
Field: [u'choice1', u'choice2']. This patch serializes the data
properly using the already defined `serialize_value` function on
form fields.