### PR TITLE
Remove references to Django < 1.7 in docs

### DIFF
--- a/docs/tutorials/widgy-mezzanine-tutorial.rst
+++ b/docs/tutorials/widgy-mezzanine-tutorial.rst
@@ -125,17 +125,17 @@ Then run the following command::
 add urls::
 
     # urls.py
-    from django.conf.urls import patterns, include, url
+    from django.conf.urls import include, url
     from demo.widgy_site import site as widgy_site
 
-    urlpatterns = patterns('',
+    urlpatterns = [
         # ...
         # widgy admin
         url(r'^admin/widgy/', include(widgy_site.urls)),
         # widgy frontend
         url(r'^widgy/', include('widgy.contrib.widgy_mezzanine.urls')),
         url(r'^', include('mezzanine.urls')),
-    )
+    ]
 
 
 Make sure you have a url pattern named ``home`` or the admin templates

--- a/docs/tutorials/widgy-mezzanine-tutorial.rst
+++ b/docs/tutorials/widgy-mezzanine-tutorial.rst
@@ -118,21 +118,9 @@ Configure django-compressor::
     for ``text/x-scss``.  Widgy uses the django-pyscss_ package for easily
     integrating the pyScss_ library with Django.
 
-.. note::
-
-    If you are using a version of Django older than 1.7, you will need use
-    South 1.0 or set SOUTH_MIGRATION_MODULES.
-
 Then run the following command::
 
     $ python manage.py migrate
-
-.. note::
-
-    If you are on a version of Django older than 1.7, you will need to run the
-    following command as well::
-
-        $ python manage.py syncdb
 
 add urls::
 


### PR DESCRIPTION
We no longer support any versions of Django 1.6
