### PR TITLE
Remove deprecated filer templatetag

### DIFF
--- a/widgy/templates/admin/filer/base_site.html
+++ b/widgy/templates/admin/filer/base_site.html
@@ -1,11 +1,10 @@
 {% extends "admin/base_site.html" %}
 {% load i18n %}
-{% load filermedia %}
 {% load compress %}
 {% load staticfiles %}
 
 {% block extrastyle %}{{ block.super }}
-<link rel="stylesheet" type="text/css" href="{% filer_staticmedia_prefix %}css/admin_style.css" />
+<link rel="stylesheet" type="text/css" href="{% static 'filer/css/admin_style.css' %}" />
 {% compress css %}
 <link rel="stylesheet" type="text/x-scss" href="{% static 'widgy/css/admin_filer_override.scss' %}">
 {% endcompress %}

--- a/widgy/templates/admin/filer/folder/directory_table.html
+++ b/widgy/templates/admin/filer/folder/directory_table.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-{% load admin_list filermedia filer_tags %}
+{% load admin_list filer_tags staticfiles %}
 
 <div id="toolbartable">
     <table cellspacing="0">
@@ -37,7 +37,7 @@
                 <!-- FileIcon -->
                 <td>
                   {% if item_perms.change %}<a href="{{ file.get_admin_url_path }}{% if is_popup %}?_popup=1{% if select_folder %}&select_folder=1{% endif %}{% endif %}" {% if is_popup %}onclick="opener.dismissRelatedImageLookupPopup(window, {{ file.id }}, '{{ file.icons.48|escapejs }}', '{{ file.label|escapejs }}'); return false;"{% endif %} title="{% blocktrans with file.label as item_label %}Change '{{ item_label }}' details{% endblocktrans %}">{% endif %}
-                    <img src="{% if file.icons.48 %}{{ file.icons.48 }}{% else %}{% filer_staticmedia_prefix %}icons/missingfile_48x48.png{% endif %}" alt="{{ file.default_alt_text }}" />
+                    <img src="{% if file.icons.48 %}{{ file.icons.48 }}{% else %}{% static 'filer/icons/missingfile_48x48.png' %}{% endif %}" alt="{{ file.default_alt_text }}" />
                   {% if item_perms.change %}</a>{% endif %}
                </td>
                 <!-- Filename/Dimensions -->


### PR DESCRIPTION
Filer now uses staticfiles rather than
filer_staticmedia_prefix.

This was removed in django-filer b29e7cc8d488f5c.