### PR TITLE
Allow build_url to take args and kwargs

### DIFF
--- a/widgy/utils.py
+++ b/widgy/utils.py
@@ -14,6 +14,7 @@ from django.template.loader import select_template, get_template
 from django.db import models
 from django.db.models import query
 from django.utils.http import urlencode
+from django.http.request import QueryDict
 from django.utils.functional import memoize
 from django.conf import settings
 
@@ -90,9 +91,26 @@ def update_context(context, dict):
     context.pop()
 
 
-def build_url(path, **kwargs):
+def build_url(path, *args, **kwargs):
+    if args:
+        if len(args) != 1:
+            raise ValueError("Length of args must be exactly 1.")
+        if kwargs:
+            raise ValueError("You may not specify both args and kwargs.")
+
+        arg = args[0]
+        if len(arg):
+            if isinstance(arg, QueryDict):
+                path += '?' + arg.urlencode()
+            else:
+                path += '?' + urlencode(args[0])
+
     if kwargs:
+        if args:
+            raise ValueError("You may not specify both args and kwargs.")
+
         path += '?' + urlencode(kwargs)
+
     return path
 
 

--- a/widgy/utils.py
+++ b/widgy/utils.py
@@ -94,9 +94,9 @@ def update_context(context, dict):
 def build_url(path, *args, **kwargs):
     if args:
         if len(args) != 1:
-            raise ValueError("Length of args must be exactly 1.")
+            raise TypeError("Length of args must be exactly 1.")
         if kwargs:
-            raise ValueError("You may not specify both args and kwargs.")
+            raise TypeError("You may not specify both args and kwargs.")
 
         arg = args[0]
         if len(arg):
@@ -107,7 +107,7 @@ def build_url(path, *args, **kwargs):
 
     if kwargs:
         if args:
-            raise ValueError("You may not specify both args and kwargs.")
+            raise TypeError("You may not specify both args and kwargs.")
 
         path += '?' + urlencode(kwargs)
 


### PR DESCRIPTION
When passing a QueryDict as a kwarg to build_url, it gets converted
into a regular dict, which is then urlencoded incorrectly. Querydict
has its own urlencode function that needs to be called.