### PR TITLE
Add valid_root_of method to WidgySite

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ Changelog
 
 - **Possible Breaking Change** Remove ``node-icon-sprite`` in
   ``widgy_common.scss`` this is incompatible with django storages.
+- Add ``WidgySite.valid_root_of`` method. You can override this method to
+  specify which layouts will be available for new pages.
 
 
 0.7.4 (2015-11-17)

--- a/docs/api/site.rst
+++ b/docs/api/site.rst
@@ -94,6 +94,11 @@ Widgy Site
     Returns the class to use as a :class:`~widgy.models.VersionTracker`.
     This can be overridden to customize versioning behavior.
 
+    .. method:: valid_root_of(self, owner_field, root_class, root_choices)
+
+    Is ``root_class`` a valid root choice for ``owner_field`` given the full
+    set of available ``root_choices``? This can be overridden to customize the
+    available layouts for the :class:`widgy.site.WidgySite`.
 
     .. rubric:: Views
 

--- a/widgy/db/fields.py
+++ b/widgy/db/fields.py
@@ -132,7 +132,7 @@ class WidgyField(models.ForeignKey):
 
         layouts = tuple(map(normalize, layouts))
         classes = (cls for cls in self.site.get_all_content_classes()
-                   if issubclass(cls, layouts))
+                   if self.site.valid_root_of(self, cls, layouts))
 
         # This method must return a queryset, because it is used as
         # choices for a ModelChoiceField.

--- a/widgy/site.py
+++ b/widgy/site.py
@@ -202,3 +202,6 @@ class WidgySite(object):
                 'widgy/{app_label}/{model_name}.admin{extension}',
                 'widgy/{app_label}/admin{extension}',
             ])
+
+    def valid_root_of(self, owner_field, root_class, root_choices):
+        return issubclass(root_class, root_choices)


### PR DESCRIPTION
This should allow better control of which layouts are available for a
given site.

This is basically Gavin Wahl's change from
https://github.com/fusionbox/django-widgy/pull/257 but passing the field
instead of the model to address Rocky Meza's concern about multiple
`WidgyField`s on a single model.
