### PR TITLE
Fix crossDomain requests in admin

### DIFF
--- a/widgy/static/widgy/js/lib/csrf.js
+++ b/widgy/static/widgy/js/lib/csrf.js
@@ -42,9 +42,8 @@ define([ 'jquery' ], function(jQuery){
     return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));
   }
   $.ajaxSetup({
-    crossDomain: false, // obviates need for sameOrigin test
     beforeSend: function(xhr, settings) {
-      if (!csrfSafeMethod(settings.type)) {
+      if (!csrfSafeMethod(settings.type) && !this.crossDomain) {
         xhr.setRequestHeader("X-CSRFToken", csrftoken);
       }
     }


### PR DESCRIPTION
Setting crossDomain = False breaks things if you're trying to use a CDN. We had removed the cross domain check before because it was ugly code, but now the django docs have a much better way to do it.
