### PR TITLE
Reset form submissions when cloning a page

### DIFF
--- a/widgy/contrib/form_builder/tests.py
+++ b/widgy/contrib/form_builder/tests.py
@@ -324,6 +324,11 @@ class TestForm(TestCase):
             "%s,\N{SNOWMAN},2,3\r\n" % (now,))
         )
 
+    def test_clone_new_page(self):
+        self.submit('a', 'b', 'c')
+        new_form = self.form.node.clone_tree(freeze=False, new_page=True).content
+        assert new_form.submissions.count() == 0
+
 
 class TestFormHandler(TestCase):
     def setUp(self):

--- a/widgy/contrib/widgy_mezzanine/views.py
+++ b/widgy/contrib/widgy_mezzanine/views.py
@@ -195,7 +195,7 @@ class ClonePageView(AdminViewMixin, UpdateView):
     def form_valid(self, form):
         page = form.instance
         unset_pks(page)
-        page.root_node = page.root_node.clone()
+        page.root_node = page.root_node.clone(new_page=True)
         page.status = CONTENT_STATUS_DRAFT
         form.save()
 

--- a/widgy/models/versioning.py
+++ b/widgy/models/versioning.py
@@ -197,9 +197,9 @@ class VersionTracker(models.Model):
                 for attr in self.get_owner_related_names()
                 for owner in getattr(self, attr).all()]
 
-    def clone(self):
+    def clone(self, new_page=False):
         vt = copy.copy(self)
-        vt.working_copy = vt.working_copy.clone_tree(freeze=False)
+        vt.working_copy = vt.working_copy.clone_tree(freeze=False, new_page=new_page)
         commits = list(self._commits_to_clone())
         unset_pks(vt)
         vt.head = None


### PR DESCRIPTION
When cloning a Widgy page with a form, you don't expect the form on the new page to share submissions with the old. Our original behavior of having clones share the same submissions only works for cloning for the purpose of versioning.
