### PR TITLE
Fix tabs widget js unquoted url bug (breaks tabs with jQuery 2.2.0)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 0.8.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix bug in tabs widget when using newer versions of jQuery 
 
 
 0.8.4 (2016-06-03)

--- a/widgy/contrib/page_builder/static/widgy/page_builder/tabs.js
+++ b/widgy/contrib/page_builder/static/widgy/page_builder/tabs.js
@@ -4,7 +4,7 @@ jQuery(function($) {
         tabify = $(this).closest('.tabify'),
         tabContent = tabify.find(href).first();
     tabify.children('.tabs').find('a').removeClass('active'); // clear the active tabs
-    tabify.children('.tabs').find('a[href=' + href + ']').addClass('active'); // activate the clicked tab
+    tabify.children('.tabs').find('a[href="' + href + '"]').addClass('active'); // activate the clicked tab
     tabify.children('.tabContent').removeClass('active'); // clear the active content
     tabContent.addClass('active'); // show the clicked content
     // Change the hash without scrolling


### PR DESCRIPTION
The # in tabs anchors is a special character and needed to be quoted in
a jQuery query. This bug didn't cause any errors for older versions of
jQuery but broke the tabs widget when using jQuery 2.2.0.
