### PR TITLE
Update form tags

### DIFF
--- a/tests/core_tests/tests/test_core.py
+++ b/tests/core_tests/tests/test_core.py
@@ -1,4 +1,6 @@
 from __future__ import absolute_import
+
+import json
 from pprint import pprint
 import datetime
 import time
@@ -6,6 +8,7 @@ import mock
 import unittest
 import contextlib
 
+from django.core import serializers
 from django.test import TestCase
 from django.test.client import RequestFactory
 from django.contrib.auth.models import User
@@ -271,7 +274,9 @@ class TestCore(RootNodeTestCase):
         tag = Tag.objects.create(name='foo')
         widget.tags.add(tag)
         widget.save()
-        self.assertEqual(widget.get_attributes(), {'tags': [tag]})
+        attributes = json.loads(widget.get_attributes()['tags'])
+        self.assertEqual(len(attributes), 1)
+        self.assertEqual(attributes[0]['fields']['name'], 'foo')
 
 
 class TestRegistry(RootNodeTestCase):

--- a/widgy/forms.py
+++ b/widgy/forms.py
@@ -8,7 +8,6 @@ from django.utils.translation import ugettext_lazy as _
 from django.utils.html import format_html
 from django.urls import reverse
 from django.core.exceptions import ObjectDoesNotExist
-from django.core import serializers
 from django.conf import settings
 from django.template.defaultfilters import capfirst
 
@@ -39,16 +38,11 @@ class WidgyWidget(forms.HiddenInput):
         assert hasattr(self, 'node'), "You must set the node on a WidgyWidget prior to rendering it."
 
         self.node.maybe_prefetch_tree()
-        node_dict = self.node.to_json(self.site)
-        if 'tags' in node_dict['content']['attributes']:
-            tag_queryset_json = serializers.serialize('json', node_dict['content']['attributes']['tags'])
-            node_dict['content']['attributes']['tags'] = tag_queryset_json
-
         defaults = {
             'html_name': name,
             'value': value,
             'html_id': attrs['id'],
-            'node_dict': node_dict,
+            'node_dict': self.node.to_json(self.site),
             'node': self.node,
             'api_url': reverse(self.site.node_view),
             'site': self.site,

--- a/widgy/forms.py
+++ b/widgy/forms.py
@@ -8,6 +8,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.utils.html import format_html
 from django.urls import reverse
 from django.core.exceptions import ObjectDoesNotExist
+from django.core import serializers
 from django.conf import settings
 from django.template.defaultfilters import capfirst
 
@@ -38,11 +39,16 @@ class WidgyWidget(forms.HiddenInput):
         assert hasattr(self, 'node'), "You must set the node on a WidgyWidget prior to rendering it."
 
         self.node.maybe_prefetch_tree()
+        node_dict = self.node.to_json(self.site)
+        if 'tags' in node_dict['content']['attributes']:
+            tag_queryset_json = serializers.serialize('json', node_dict['content']['attributes']['tags'])
+            node_dict['content']['attributes']['tags'] = tag_queryset_json
+
         defaults = {
             'html_name': name,
             'value': value,
             'html_id': attrs['id'],
-            'node_dict': self.node.to_json(self.site),
+            'node_dict': node_dict,
             'node': self.node,
             'api_url': reverse(self.site.node_view),
             'site': self.site,

--- a/widgy/models/base.py
+++ b/widgy/models/base.py
@@ -8,8 +8,10 @@ import logging
 import itertools
 import copy
 
+from django.core import serializers
 from django.db import models, transaction
 from django import forms
+from django.db.models import ManyToManyField
 from django.forms.models import modelform_factory, ModelForm
 from django.contrib.contenttypes.models import ContentType
 from django.template import RequestContext
@@ -473,7 +475,10 @@ class Content(models.Model):
         model_data = {}
         for field in itertools.chain(self._meta.concrete_fields, self._meta.many_to_many):
             if field.serialize:
-                model_data[field.attname] = field.value_from_object(self)
+                if isinstance(field, ManyToManyField):
+                    model_data[field.attname] = serializers.serialize('json', field.value_from_object(self))
+                else:
+                    model_data[field.attname] = field.value_from_object(self)
         return model_data
 
     @classmethod

--- a/widgy/models/base.py
+++ b/widgy/models/base.py
@@ -11,7 +11,6 @@ import copy
 from django.core import serializers
 from django.db import models, transaction
 from django import forms
-from django.db.models import ManyToManyField
 from django.forms.models import modelform_factory, ModelForm
 from django.contrib.contenttypes.models import ContentType
 from django.template import RequestContext
@@ -475,7 +474,7 @@ class Content(models.Model):
         model_data = {}
         for field in itertools.chain(self._meta.concrete_fields, self._meta.many_to_many):
             if field.serialize:
-                if isinstance(field, ManyToManyField):
+                if isinstance(field, models.ManyToManyField):
                     model_data[field.attname] = serializers.serialize('json', field.value_from_object(self))
                 else:
                     model_data[field.attname] = field.value_from_object(self)


### PR DESCRIPTION
Serialized the Tag queryset object to json format. Needed to change the format because the Tag queryset object couldn't be jsonified with to_json.